### PR TITLE
Add verbose logging for WebSocket connections

### DIFF
--- a/cmd/wsget/main.go
+++ b/cmd/wsget/main.go
@@ -23,6 +23,7 @@ var outputFile string
 var inputFile string
 var headers []string
 var waitResponse int
+var verbose bool
 var Version = "dev"
 
 const (
@@ -67,6 +68,7 @@ func main() {
 	cmd.Flags().IntVarP(&waitResponse, "wait-resp", "w", -1, "Timeout for single response in seconds, 0 means no timeout. If this option is set, the tool will exit after receiving the first response")
 	cmd.Flags().StringSliceVarP(&headers, "header", "H", []string{}, "HTTP headers to attach to the request")
 	cmd.Flags().StringVarP(&inputFile, "input", "i", "", "Input YAML file with list of requests to send to the server")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		fmt.Println(err)
@@ -89,7 +91,15 @@ func run(cmnd *cobra.Command, args []string) {
 		return
 	}
 
-	wsConn, err := ws.NewWS(cmnd.Context(), wsURL, ws.Options{SkipSSLVerification: insecure, Headers: headers})
+	wsConn, err := ws.NewWS(
+		cmnd.Context(),
+		wsURL,
+		ws.Options{
+			SkipSSLVerification: insecure,
+			Headers:             headers,
+			Verbose:             verbose,
+		},
+	)
 	if err != nil {
 		color.New(color.FgRed).Println("Unable to connect to the server: ", err)
 		return

--- a/pkg/ws/ws.go
+++ b/pkg/ws/ws.go
@@ -58,6 +58,7 @@ type Connection struct {
 type Options struct {
 	Headers             []string
 	SkipSSLVerification bool
+	Verbose             bool
 }
 
 type ConnectionHandler interface {

--- a/pkg/ws/ws.go
+++ b/pkg/ws/ws.go
@@ -76,24 +76,27 @@ type requestLogger struct {
 
 // RoundTrip logs the request and response details.
 func (t *requestLogger) RoundTrip(req *http.Request) (*http.Response, error) {
-	tx := color.New(color.FgGreen)
+	if t.verbose {
+		tx := color.New(color.FgGreen)
 
-	tx.Printf("> %s %s %s\n", req.Method, req.URL.String(), req.Proto)
-	printHeaders(req.Header, tx, ">")
-	tx.Println()
+		tx.Printf("> %s %s %s\n", req.Method, req.URL.String(), req.Proto)
+		printHeaders(req.Header, tx, ">")
+		tx.Println()
+	}
 
 	resp, err := t.transport.RoundTrip(req)
 
 	if err != nil {
-		color.New(color.FgRed).Println("Fail to send request:", err)
 		return nil, err
 	}
 
-	rx := color.New(color.FgYellow)
+	if t.verbose {
+		rx := color.New(color.FgYellow)
 
-	rx.Printf("< %s %s\n", resp.Proto, resp.Status)
-	printHeaders(resp.Header, rx, "<")
-	rx.Println()
+		rx.Printf("< %s %s\n", resp.Proto, resp.Status)
+		printHeaders(resp.Header, rx, "<")
+		rx.Println()
+	}
 
 	return resp, nil
 }

--- a/pkg/ws/ws.go
+++ b/pkg/ws/ws.go
@@ -98,6 +98,10 @@ func NewWS(ctx context.Context, wsURL string, opts Options) (*Connection, error)
 			header := strings.TrimSpace(splited[0])
 			value := strings.TrimSpace(splited[1])
 
+			if opts.Verbose {
+				color.New(color.FgYellow).Printf("> %s: %s\n", header, value)
+			}
+
 			Headers.Add(header, value)
 		}
 
@@ -107,6 +111,14 @@ func NewWS(ctx context.Context, wsURL string, opts Options) (*Connection, error)
 	ws, resp, err := websocket.Dial(ctx, wsURL, wsOpts)
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.Verbose {
+		for header, values := range resp.Header {
+			for _, value := range values {
+				color.New(color.FgYellow).Printf("< %s: %s\n", header, value)
+			}
+		}
 	}
 
 	if resp.Body != nil {

--- a/pkg/ws/ws.go
+++ b/pkg/ws/ws.go
@@ -101,7 +101,7 @@ func (t *requestLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 // printHeaders prints the headers to the output with the given prefix.
 func printHeaders(headers http.Header, out *color.Color, prefix string) {
 	// Sort headers for consistent output
-	var headerNames []string
+	headerNames := make([]string, 0, len(headers))
 	for header := range headers {
 		headerNames = append(headerNames, header)
 	}


### PR DESCRIPTION
Introduce a verbose flag for enhanced logging of HTTP request and response details in WebSocket connections, improving visibility and debugging capabilities. Refactor and optimize related logging functions for better readability and performance.