### PR TITLE
Add cursor movement functions for row navigation

### DIFF
--- a/pkg/edit/content.go
+++ b/pkg/edit/content.go
@@ -163,6 +163,37 @@ func (c *Content) Clear() string {
 	return output
 }
 
+// MoveToStart moves the cursor to the beginning of the current line
+func (c *Content) MoveToRowStart() string {
+	if c.pos == 0 {
+		return ""
+	}
+
+	output := ""
+
+	for c.pos > 0 && c.text[c.pos-1] != NewLine {
+		output += Backspace
+		c.pos--
+	}
+
+	return output
+}
+
+// MoveToEnd moves the cursor to the end of current line
+func (c *Content) MoveToRowEnd() string {
+	if c.pos >= len(c.text) {
+		return ""
+	}
+
+	init := c.pos
+
+	for c.pos < len(c.text) && c.text[c.pos] != NewLine {
+		c.pos++
+	}
+
+	return string(c.text[init:c.pos])
+}
+
 // RemoveSymbol removes the symbol at the current position of the Content object and returns the string representation of the changes made.
 // If the current position is out of bounds, an empty string is returned.
 // If the removed symbol is not a newline character, the function returns the string representation of the changes made, including clearing the current line and moving the cursor to the beginning of the line.

--- a/pkg/edit/content.go
+++ b/pkg/edit/content.go
@@ -163,7 +163,11 @@ func (c *Content) Clear() string {
 	return output
 }
 
-// MoveToStart moves the cursor to the beginning of the current line
+// MoveToRowStart moves the cursor position to the start of the current row.
+// It updates the cursor position and returns a string of backspace characters
+// needed to move the cursor to the start of the row.
+// It takes no parameters and returns a string.
+// If the cursor is already at the start of the row (position 0), it returns an empty string.
 func (c *Content) MoveToRowStart() string {
 	if c.pos == 0 {
 		return ""
@@ -179,7 +183,9 @@ func (c *Content) MoveToRowStart() string {
 	return output
 }
 
-// MoveToEnd moves the cursor to the end of current line
+// MoveToRowEnd moves the position within the text to the end of the current row.
+// It returns the substring from the initial position to the end of the row.
+// If the current position is already at or beyond the end of the text, it returns an empty string.
 func (c *Content) MoveToRowEnd() string {
 	if c.pos >= len(c.text) {
 		return ""

--- a/pkg/edit/content_test.go
+++ b/pkg/edit/content_test.go
@@ -743,3 +743,106 @@ func TestContent_MoveToRowStart(t *testing.T) {
 		})
 	}
 }
+func TestContent_MoveToRowEnd(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     *Content
+		expected    string
+		expectedPos int
+	}{
+		{
+			name: "cursor at the beginning of a single line",
+			content: &Content{
+				text: []rune("hello world"),
+				pos:  0,
+			},
+			expected:    "hello world",
+			expectedPos: 11,
+		},
+		{
+			name: "cursor in the middle of a single line",
+			content: &Content{
+				text: []rune("hello world"),
+				pos:  6,
+			},
+			expected:    "world",
+			expectedPos: 11,
+		},
+		{
+			name: "cursor at the end of a single line",
+			content: &Content{
+				text: []rune("hello world"),
+				pos:  11,
+			},
+			expected:    "",
+			expectedPos: 11,
+		},
+		{
+			name: "cursor at the beginning of a multi-line content",
+			content: &Content{
+				text: []rune("hello\nworld"),
+				pos:  0,
+			},
+			expected:    "hello",
+			expectedPos: 5,
+		},
+		{
+			name: "cursor in the middle of a multi-line content",
+			content: &Content{
+				text: []rune("hello\nworld"),
+				pos:  3,
+			},
+			expected:    "lo",
+			expectedPos: 5,
+		},
+		{
+			name: "cursor at the end of a line in multi-line content",
+			content: &Content{
+				text: []rune("hello\nworld"),
+				pos:  5,
+			},
+			expected:    "",
+			expectedPos: 5,
+		},
+		{
+			name: "cursor at the beginning of the second line in multi-line content",
+			content: &Content{
+				text: []rune("hello\nworld"),
+				pos:  6,
+			},
+			expected:    "world",
+			expectedPos: 11,
+		},
+		{
+			name: "cursor in the middle of the second line in multi-line content",
+			content: &Content{
+				text: []rune("hello\nworld"),
+				pos:  8,
+			},
+			expected:    "rld",
+			expectedPos: 11,
+		},
+		{
+			name: "cursor at the end of the second line in multi-line content",
+			content: &Content{
+				text: []rune("hello\nworld"),
+				pos:  11,
+			},
+			expected:    "",
+			expectedPos: 11,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.content.MoveToRowEnd()
+			if actual != tt.expected {
+				t.Errorf("expected %q, but got %q", tt.expected, actual)
+			}
+
+			if tt.content.pos != tt.expectedPos {
+				t.Errorf("expected position %d, but got %d", tt.expectedPos, tt.content.pos)
+			}
+		})
+	}
+}

--- a/pkg/edit/content_test.go
+++ b/pkg/edit/content_test.go
@@ -675,3 +675,71 @@ func TestContent_MoveToPrevWord(t *testing.T) {
 		})
 	}
 }
+
+func TestContent_MoveToRowStart(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     *Content
+		expected    string
+		expectedPos int
+	}{
+		{
+			name: "cursor at the beginning of the content",
+			content: &Content{
+				text: []rune("hello world"),
+				pos:  0,
+			},
+			expected:    "",
+			expectedPos: 0,
+		},
+		{
+			name: "cursor at the beginning of a line",
+			content: &Content{
+				text: []rune("hello\nworld"),
+				pos:  6,
+			},
+			expected:    "",
+			expectedPos: 6,
+		},
+		{
+			name: "cursor in the middle of a line",
+			content: &Content{
+				text: []rune("hello\nworld"),
+				pos:  8,
+			},
+			expected:    "\b\b",
+			expectedPos: 6,
+		},
+		{
+			name: "cursor at the end of a line",
+			content: &Content{
+				text: []rune("hello world"),
+				pos:  11,
+			},
+			expected:    "\b\b\b\b\b\b\b\b\b\b\b",
+			expectedPos: 0,
+		},
+		{
+			name: "cursor in the middle of a multiline content",
+			content: &Content{
+				text: []rune("hello\nworld\nfoo"),
+				pos:  11,
+			},
+			expected:    "\b\b\b\b\b",
+			expectedPos: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.content.MoveToRowStart()
+			if actual != tt.expected {
+				t.Errorf("expected %q, but got %q", tt.expected, actual)
+			}
+
+			if tt.content.pos != tt.expectedPos {
+				t.Errorf("expected position %d, but got %d", tt.expectedPos, tt.content.pos)
+			}
+		})
+	}
+}

--- a/pkg/edit/editor.go
+++ b/pkg/edit/editor.go
@@ -110,6 +110,10 @@ func (ed *Editor) Edit(keyStream <-chan keyboard.KeyEvent, initBuffer string) (s
 			for _, r := range diff {
 				fmt.Fprint(ed.output, ed.content.InsertSymbol(r))
 			}
+		case keyboard.KeyHome:
+			fmt.Fprint(ed.output, ed.content.MoveToRowStart())
+		case keyboard.KeyEnd:
+			fmt.Fprint(ed.output, ed.content.MoveToRowEnd())
 		default:
 			if e.Key > 0 {
 				continue


### PR DESCRIPTION
Introduce `MoveToRowStart` and `MoveToRowEnd` functions for cursor navigation, along with corresponding tests to ensure functionality. Update the editor to handle home and end key events for these new functions.