### PR TITLE
Add key binding for deleting to the previous and next word

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
   enable:
     - bodyclose
     - dogsled
-    - dupl
     - errcheck
     - exhaustive
     - goconst

--- a/pkg/edit/content.go
+++ b/pkg/edit/content.go
@@ -171,6 +171,31 @@ func (c *Content) DeleteToPrevWord() string {
 	return buf.String()
 }
 
+func (c *Content) DeleteToNextWord() string {
+	if c.pos >= len(c.text) {
+		return ""
+	}
+
+	pos := c.pos
+
+	// move to the end of the current word
+	for pos < len(c.text) && isWord(c.text[pos]) {
+		pos++
+	}
+
+	// move to the beginning of the next word
+	for pos < len(c.text) && !isWord(c.text[pos]) {
+		pos++
+	}
+
+	buf := bytes.NewBufferString("")
+	for i := c.pos; i < pos; i++ {
+		fmt.Fprint(buf, c.RemoveNextSymbol())
+	}
+
+	return buf.String()
+}
+
 // Clear clears the content and returns the string representation of the cleared content.
 // If the content is already empty, it returns an empty string.
 func (c *Content) Clear() string {

--- a/pkg/edit/content.go
+++ b/pkg/edit/content.go
@@ -141,6 +141,7 @@ func (c *Content) MoveToPrevWord() string {
 	return buf.String()
 }
 
+// DeleteToPrevWord deletes characters from the current position to the beginning of current or previous word in the content.
 func (c *Content) DeleteToPrevWord() string {
 	if c.pos <= 0 {
 		return ""
@@ -171,6 +172,7 @@ func (c *Content) DeleteToPrevWord() string {
 	return buf.String()
 }
 
+// DeleteToNextWord deletes characters from the current position to the beginning of the next word in the content.
 func (c *Content) DeleteToNextWord() string {
 	if c.pos >= len(c.text) {
 		return ""
@@ -304,12 +306,11 @@ func (c *Content) RemovePrevSymbol() string {
 	return output
 }
 
-// RemoveNextSymbol removes the next symbol from the content's text at the current position.
-// It adjusts the position and updates the text accordingly.
-// It returns a string representing the changes to be displayed.
+// RemoveNextSymbol removes the symbol at the current position in the content's text and returns a string representing the updated text or necessary control characters for display.
+// It takes no parameters.
+// It returns a string which is the updated text or control characters for display.
 // If the current position is out of bounds, it returns an empty string.
-// If the removed symbol is not a newline, it returns a string to clear and update the current line.
-// If the removed symbol is a newline, it returns a string to clear and update the current and next line(s).
+// If the symbol at the current position is a newline, it handles the line break and returns the appropriate control characters to update the display.
 func (c *Content) RemoveNextSymbol() string {
 	if c.pos < 0 || c.pos >= len(c.text) {
 		return ""
@@ -326,10 +327,6 @@ func (c *Content) RemoveNextSymbol() string {
 	}
 
 	c.text = buffer
-
-	if c.pos == len(c.text) && symbol != NewLine {
-		return " " + Backspace
-	}
 
 	if symbol != NewLine {
 		endCurrentLine := startCurrentLine + len(lines[0])

--- a/pkg/edit/content.go
+++ b/pkg/edit/content.go
@@ -141,6 +141,36 @@ func (c *Content) MoveToPrevWord() string {
 	return buf.String()
 }
 
+func (c *Content) DeleteToPrevWord() string {
+	if c.pos <= 0 {
+		return ""
+	}
+
+	pos := c.pos - 1
+
+	// Handle case where case in the beginning of the word
+	if pos > 0 && isWord(c.text[pos]) {
+		pos--
+	}
+
+	// Move to the end of previous word
+	for pos > 0 && !isWord(c.text[pos]) {
+		pos--
+	}
+
+	// Move to the beginning of the previous word
+	for pos > 0 && isWord(c.text[pos-1]) {
+		pos--
+	}
+
+	buf := bytes.NewBufferString("")
+	for i := c.pos - 1; pos <= i; i-- {
+		fmt.Fprint(buf, c.RemoveSymbol())
+	}
+
+	return buf.String()
+}
+
 // Clear clears the content and returns the string representation of the cleared content.
 // If the content is already empty, it returns an empty string.
 func (c *Content) Clear() string {

--- a/pkg/edit/content.go
+++ b/pkg/edit/content.go
@@ -436,6 +436,10 @@ func (c *Content) PrevSymbol() rune {
 		return 0
 	}
 
+	if c.pos > len(c.text) {
+		c.pos = len(c.text)
+	}
+
 	return c.text[c.pos-1]
 }
 

--- a/pkg/edit/content.go
+++ b/pkg/edit/content.go
@@ -292,23 +292,26 @@ func (c *Content) RemoveNextSymbol() string {
 
 	symbol := c.text[c.pos]
 
-	if c.pos == len(c.text)-1 {
-		c.text = c.text[:c.pos]
-		return ""
-	}
-
 	startCurrentLine, lines := c.GetLinesAfterPosition(c.pos)
 
 	buffer := c.text[:c.pos]
-	buffer = append(buffer, c.text[c.pos+1:]...)
+
+	if c.pos < (len(c.text) - 1) {
+		buffer = append(buffer, c.text[c.pos+1:]...)
+	}
+
 	c.text = buffer
+
+	if c.pos == len(c.text) && symbol != NewLine {
+		return " " + Backspace
+	}
 
 	if symbol != NewLine {
 		endCurrentLine := startCurrentLine + len(lines[0])
-		return LineClear + ReturnCarriege + string(c.text[startCurrentLine:endCurrentLine]) + ReturnCarriege + string(c.text[startCurrentLine:c.pos])
+		return LineClear + ReturnCarriege + string(c.text[startCurrentLine:endCurrentLine-1]) + ReturnCarriege + string(c.text[startCurrentLine:c.pos])
 	}
 
-	output := LineClear + ReturnCarriege + lines[0]
+	output := ""
 	moveUp := ""
 
 	for i := 1; i < len(lines); i++ {
@@ -318,6 +321,7 @@ func (c *Content) RemoveNextSymbol() string {
 
 	if moveUp != "" {
 		output += moveUp
+		output += ReturnCarriege + lines[0]
 	}
 
 	return output

--- a/pkg/edit/content_test.go
+++ b/pkg/edit/content_test.go
@@ -961,3 +961,118 @@ func TestContent_RemoveNextSymbol(t *testing.T) {
 		})
 	}
 }
+
+func TestContent_DeleteToPrevWord(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputText      string
+		inputPos       int
+		expectedOutput string
+		expectedText   string
+		expectedPos    int
+	}{
+		{
+			name:           "Delete previous word when cursor is at the end",
+			inputText:      "hello world",
+			inputPos:       11,
+			expectedOutput: "\b \b\b \b\b \b\b \b\b \b",
+			expectedText:   "hello ",
+			expectedPos:    6,
+		},
+		{
+			name:           "Delete to previous word when cursor is in the middle of a word",
+			inputText:      "hello world",
+			inputPos:       8,
+			expectedOutput: "\x1b[2K\rhello wrld\rhello w\x1b[2K\rhello rld\rhello ",
+			expectedText:   "hello rld",
+			expectedPos:    6,
+		},
+		{
+			name:           "Delete to previous word when cursor is at the beginning of a word",
+			inputText:      "hello world",
+			inputPos:       6,
+			expectedOutput: "\x1b[2K\rhelloworld\rhello\x1b[2K\rhellworld\rhell\x1b[2K\rhelworld\rhel\x1b[2K\rheworld\rhe\x1b[2K\rhworld\rh\x1b[2K\rworld\r",
+			expectedText:   "world",
+			expectedPos:    0,
+		},
+		{
+			name:           "Delete to previous word when there is no previous word",
+			inputText:      "hello world",
+			inputPos:       0,
+			expectedOutput: "",
+			expectedText:   "hello world",
+			expectedPos:    0,
+		},
+		{
+			name:           "Delete to previous word when there are multiple spaces",
+			inputText:      "hello   world",
+			inputPos:       13,
+			expectedOutput: "\b \b\b \b\b \b\b \b\b \b",
+			expectedText:   "hello   ",
+			expectedPos:    8,
+		},
+		{
+			name:           "Delete to previous word when there is only one word",
+			inputText:      "world",
+			inputPos:       5,
+			expectedOutput: "\b \b\b \b\b \b\b \b\b \b",
+			expectedText:   "",
+			expectedPos:    0,
+		},
+		{
+			name:           "Delete to previous word in empty content",
+			inputText:      "",
+			inputPos:       0,
+			expectedOutput: "",
+			expectedText:   "",
+			expectedPos:    0,
+		},
+		{
+			name:           "Delete to previous word with punctuation",
+			inputText:      "hello, world!",
+			inputPos:       13,
+			expectedOutput: "\b \b\b \b\b \b\b \b\b \b\b \b",
+			expectedText:   "hello, ",
+			expectedPos:    7,
+		},
+		{
+			name:           "Delete to previous word with cursor in whitespace",
+			inputText:      "hello    ",
+			inputPos:       9,
+			expectedOutput: "\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b\b \b",
+			expectedText:   "",
+			expectedPos:    0,
+		},
+		{
+			name:           "Delete to previous word with multiple non-word characters",
+			inputText:      "hello---world",
+			inputPos:       13,
+			expectedOutput: "\b \b\b \b\b \b\b \b\b \b",
+			expectedText:   "hello---",
+			expectedPos:    8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Content{
+				text: []rune(tt.inputText),
+				pos:  tt.inputPos,
+			}
+
+			output := c.DeleteToPrevWord()
+
+			if output != tt.expectedOutput {
+				t.Errorf("expected output %q, but got %q", tt.expectedOutput, output)
+			}
+
+			if string(c.text) != tt.expectedText {
+				t.Errorf("expected text %q, but got %q", tt.expectedText, string(c.text))
+			}
+
+			if c.pos != tt.expectedPos {
+				t.Errorf("expected position %d, but got %d", tt.expectedPos, c.pos)
+			}
+		})
+	}
+}

--- a/pkg/edit/content_test.go
+++ b/pkg/edit/content_test.go
@@ -326,7 +326,7 @@ func TestContent_RemoveSymbol(t *testing.T) {
 				pos:  tt.pos,
 			}
 
-			output := content.RemoveSymbol()
+			output := content.RemovePrevSymbol()
 
 			if output != tt.output {
 				t.Errorf("expected output %q, but got %q", tt.output, output)

--- a/pkg/edit/content_test.go
+++ b/pkg/edit/content_test.go
@@ -1191,3 +1191,74 @@ func TestContent_DeleteToNextWord(t *testing.T) {
 		})
 	}
 }
+
+func TestContent_PrevSymbol(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		pos      int
+		expected rune
+	}{
+		{
+			name:     "Cursor at the beginning",
+			text:     "hello",
+			pos:      0,
+			expected: 0,
+		},
+		{
+			name:     "Cursor in the middle",
+			text:     "hello",
+			pos:      2,
+			expected: 'e',
+		},
+		{
+			name:     "Cursor at the end",
+			text:     "hello",
+			pos:      5,
+			expected: 'o',
+		},
+		{
+			name:     "Cursor out of bounds (negative)",
+			text:     "hello",
+			pos:      -1,
+			expected: 0,
+		},
+		{
+			name:     "Cursor out of bounds (beyond length)",
+			text:     "hello",
+			pos:      6,
+			expected: 'o',
+		},
+		{
+			name:     "Empty text",
+			text:     "",
+			pos:      0,
+			expected: 0,
+		},
+		{
+			name:     "Cursor after newline character",
+			text:     "hello\nworld",
+			pos:      6,
+			expected: '\n',
+		},
+		{
+			name:     "Cursor at position 1",
+			text:     "a",
+			pos:      1,
+			expected: 'a',
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Content{
+				text: []rune(tt.text),
+				pos:  tt.pos,
+			}
+			got := c.PrevSymbol()
+			if got != tt.expected {
+				t.Errorf("PrevSymbol() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/edit/content_test.go
+++ b/pkg/edit/content_test.go
@@ -851,9 +851,9 @@ func TestContent_RemoveNextSymbol(t *testing.T) {
 	tests := []struct {
 		name         string
 		input        string
-		pos          int
 		output       string
 		expectedText string
+		pos          int
 		expectedPos  int
 	}{
 		{
@@ -966,9 +966,9 @@ func TestContent_DeleteToPrevWord(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputText      string
-		inputPos       int
 		expectedOutput string
 		expectedText   string
+		inputPos       int
 		expectedPos    int
 	}{
 		{
@@ -1081,9 +1081,9 @@ func TestContent_DeleteToNextWord(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputText      string
-		inputPos       int
 		expectedOutput string
 		expectedText   string
+		inputPos       int
 		expectedPos    int
 	}{
 		{
@@ -1255,8 +1255,8 @@ func TestContent_PrevSymbol(t *testing.T) {
 				text: []rune(tt.text),
 				pos:  tt.pos,
 			}
-			got := c.PrevSymbol()
-			if got != tt.expected {
+
+			if got := c.PrevSymbol(); got != tt.expected {
 				t.Errorf("PrevSymbol() = %q, want %q", got, tt.expected)
 			}
 		})

--- a/pkg/edit/content_test.go
+++ b/pkg/edit/content_test.go
@@ -1076,3 +1076,118 @@ func TestContent_DeleteToPrevWord(t *testing.T) {
 		})
 	}
 }
+
+func TestContent_DeleteToNextWord(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputText      string
+		inputPos       int
+		expectedOutput string
+		expectedText   string
+		expectedPos    int
+	}{
+		{
+			name:           "Delete to next word when cursor is at the beginning of a word",
+			inputText:      "hello world",
+			inputPos:       0,
+			expectedOutput: "\x1b[2K\rello world\r\x1b[2K\rllo world\r\x1b[2K\rlo world\r\x1b[2K\ro world\r\x1b[2K\r world\r\x1b[2K\rworld\r",
+			expectedText:   "world",
+			expectedPos:    0,
+		},
+		{
+			name:           "Delete to next word when cursor is in the middle of a word",
+			inputText:      "hello world",
+			inputPos:       2,
+			expectedOutput: "\x1b[2K\rhelo world\rhe\x1b[2K\rheo world\rhe\x1b[2K\rhe world\rhe\x1b[2K\rheworld\rhe",
+			expectedText:   "heworld",
+			expectedPos:    2,
+		},
+		{
+			name:           "Delete to next word when cursor is at the end of a word",
+			inputText:      "hello world",
+			inputPos:       5,
+			expectedOutput: "\x1b[2K\rhelloworld\rhello",
+			expectedText:   "helloworld",
+			expectedPos:    5,
+		},
+		{
+			name:           "Delete to next word when cursor is at whitespace",
+			inputText:      "hello   world",
+			inputPos:       5,
+			expectedOutput: "\x1b[2K\rhello  world\rhello\x1b[2K\rhello world\rhello\x1b[2K\rhelloworld\rhello",
+			expectedText:   "helloworld",
+			expectedPos:    5,
+		},
+		{
+			name:           "Delete to next word when cursor is at the end of text",
+			inputText:      "hello world",
+			inputPos:       11,
+			expectedOutput: "",
+			expectedText:   "hello world",
+			expectedPos:    11,
+		},
+		{
+			name:           "Delete to next word when there are multiple spaces",
+			inputText:      "hello   world",
+			inputPos:       2,
+			expectedOutput: "\x1b[2K\rhelo   world\rhe\x1b[2K\rheo   world\rhe\x1b[2K\rhe   world\rhe\x1b[2K\rhe  world\rhe\x1b[2K\rhe world\rhe\x1b[2K\rheworld\rhe",
+			expectedText:   "heworld",
+			expectedPos:    2,
+		},
+		{
+			name:           "Delete to next word with punctuation",
+			inputText:      "hello, world!",
+			inputPos:       5,
+			expectedOutput: "\x1b[2K\rhello world!\rhello\x1b[2K\rhelloworld!\rhello",
+			expectedText:   "helloworld!",
+			expectedPos:    5,
+		},
+		{
+			name:           "Delete to next word when cursor is at the beginning of an empty content",
+			inputText:      "",
+			inputPos:       0,
+			expectedOutput: "",
+			expectedText:   "",
+			expectedPos:    0,
+		},
+		{
+			name:           "Delete to next word when cursor is in the middle of multiple spaces",
+			inputText:      "hello     world",
+			inputPos:       7,
+			expectedOutput: "\x1b[2K\rhello    world\rhello  \x1b[2K\rhello   world\rhello  \x1b[2K\rhello  world\rhello  ",
+			expectedText:   "hello  world",
+			expectedPos:    7,
+		},
+		{
+			name:           "Delete to next word in multi-line content",
+			inputText:      "hello\nworld\nfoo",
+			inputPos:       6,
+			expectedOutput: "\x1b[2K\rorld\r\x1b[2K\rrld\r\x1b[2K\rld\r\x1b[2K\rd\r\x1b[2K\r\rfoo\n\x1b[2K\r\x1b[1A\r",
+			expectedText:   "hello\nfoo",
+			expectedPos:    6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Content{
+				text: []rune(tt.inputText),
+				pos:  tt.inputPos,
+			}
+
+			output := c.DeleteToNextWord()
+
+			if output != tt.expectedOutput {
+				t.Errorf("expected output %q, but got %q", tt.expectedOutput, output)
+			}
+
+			if string(c.text) != tt.expectedText {
+				t.Errorf("expected text %q, but got %q", tt.expectedText, string(c.text))
+			}
+
+			if c.pos != tt.expectedPos {
+				t.Errorf("expected position %d, but got %d", tt.expectedPos, c.pos)
+			}
+		})
+	}
+}

--- a/pkg/edit/content_test.go
+++ b/pkg/edit/content_test.go
@@ -846,3 +846,118 @@ func TestContent_MoveToRowEnd(t *testing.T) {
 		})
 	}
 }
+
+func TestContent_RemoveNextSymbol(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		pos          int
+		output       string
+		expectedText string
+		expectedPos  int
+	}{
+		{
+			name:         "remove symbol in the middle of the text",
+			input:        "hello world",
+			pos:          5,
+			output:       "\x1b[2K\rhelloworld\rhello",
+			expectedText: "helloworld",
+			expectedPos:  5,
+		},
+		{
+			name:         "remove symbol at the beginning of the text",
+			input:        "hello world",
+			pos:          0,
+			output:       "\x1b[2K\rello world\r",
+			expectedText: "ello world",
+			expectedPos:  0,
+		},
+		{
+			name:         "remove symbol at the end of the text",
+			input:        "hello world",
+			pos:          11,
+			output:       "",
+			expectedText: "hello world",
+			expectedPos:  11,
+		},
+		{
+			name:         "remove newline character in the middle of the text",
+			input:        "hello\nworld",
+			pos:          5,
+			output:       "world\n\x1b[2K\r\x1b[1A\rhello",
+			expectedText: "helloworld",
+			expectedPos:  5,
+		},
+		{
+			name:         "remove symbol when pos is out of bounds (negative)",
+			input:        "hello world",
+			pos:          -1,
+			output:       "",
+			expectedText: "hello world",
+			expectedPos:  -1,
+		},
+		{
+			name:         "remove symbol when pos is out of bounds (exceeds length)",
+			input:        "hello world",
+			pos:          12,
+			output:       "",
+			expectedText: "hello world",
+			expectedPos:  12,
+		},
+		{
+			name:         "remove symbol from empty content",
+			input:        "",
+			pos:          0,
+			output:       "",
+			expectedText: "",
+			expectedPos:  0,
+		},
+		{
+			name:         "remove newline at the end of the text",
+			input:        "hello world\n",
+			pos:          11,
+			output:       "\n\x1b[2K\r\x1b[1A\rhello world",
+			expectedText: "hello world",
+			expectedPos:  11,
+		},
+		{
+			name:         "remove symbol at the end when cursor is before newline",
+			input:        "hello\n",
+			pos:          5,
+			output:       "\n\x1b[2K\r\x1b[1A\rhello",
+			expectedText: "hello",
+			expectedPos:  5,
+		},
+		{
+			name:         "remove symbol when next symbol is newline",
+			input:        "hello\nworld",
+			pos:          5,
+			output:       "world\n\x1b[2K\r\x1b[1A\rhello",
+			expectedText: "helloworld",
+			expectedPos:  5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Content{
+				text: []rune(tt.input),
+				pos:  tt.pos,
+			}
+
+			output := c.RemoveNextSymbol()
+
+			if output != tt.output {
+				t.Errorf("expected output %q, but got %q", tt.output, output)
+			}
+
+			if string(c.text) != tt.expectedText {
+				t.Errorf("expected text %q, but got %q", tt.expectedText, string(c.text))
+			}
+
+			if c.pos != tt.expectedPos {
+				t.Errorf("expected position %d, but got %d", tt.expectedPos, c.pos)
+			}
+		})
+	}
+}

--- a/pkg/edit/editor.go
+++ b/pkg/edit/editor.go
@@ -95,8 +95,10 @@ func (ed *Editor) Edit(keyStream <-chan keyboard.KeyEvent, initBuffer string) (s
 			if ed.newLineOrDone(isPasting) {
 				return ed.done()
 			}
-		case keyboard.KeyBackspace, keyboard.KeyDelete, MacOSDeleteKey:
-			fmt.Fprint(ed.output, ed.content.RemoveSymbol())
+		case keyboard.KeyBackspace, MacOSDeleteKey:
+			fmt.Fprint(ed.output, ed.content.RemovePrevSymbol())
+		case keyboard.KeyDelete:
+			fmt.Fprint(ed.output, ed.content.RemoveNextSymbol())
 		case keyboard.KeyArrowLeft:
 			fmt.Fprint(ed.output, ed.content.MovePositionLeft())
 		case keyboard.KeyArrowRight:
@@ -197,7 +199,7 @@ func (ed *Editor) newLineOrDone(isPasting bool) (isDone bool) {
 
 	isDone = prev != '\\'
 	if !isDone {
-		fmt.Fprint(ed.output, ed.content.RemoveSymbol())
+		fmt.Fprint(ed.output, ed.content.RemovePrevSymbol())
 		fmt.Fprint(ed.output, ed.content.InsertSymbol('\n'))
 
 		return isDone

--- a/pkg/edit/editor.go
+++ b/pkg/edit/editor.go
@@ -68,6 +68,16 @@ func (ed *Editor) Edit(keyStream <-chan keyboard.KeyEvent, initBuffer string) (s
 			continue
 		}
 
+		if keyboard.KeyCtrlW == e.Key {
+			// Alt + Backspace
+			continue
+		}
+
+		if keyboard.KeyEsc == e.Key && e.Rune == 100 {
+			// Alt + Delete
+			continue
+		}
+
 		switch e.Key {
 		case keyboard.KeyCtrlC, keyboard.KeyCtrlD:
 			return "", clierrors.Interrupted{}

--- a/pkg/edit/editor.go
+++ b/pkg/edit/editor.go
@@ -70,6 +70,7 @@ func (ed *Editor) Edit(keyStream <-chan keyboard.KeyEvent, initBuffer string) (s
 
 		if keyboard.KeyCtrlW == e.Key {
 			// Alt + Backspace
+			fmt.Fprint(ed.output, ed.content.DeleteToPrevWord())
 			continue
 		}
 

--- a/pkg/edit/editor.go
+++ b/pkg/edit/editor.go
@@ -76,6 +76,7 @@ func (ed *Editor) Edit(keyStream <-chan keyboard.KeyEvent, initBuffer string) (s
 
 		if keyboard.KeyEsc == e.Key && e.Rune == 100 {
 			// Alt + Delete
+			fmt.Fprint(ed.output, ed.content.DeleteToNextWord())
 			continue
 		}
 

--- a/pkg/edit/editor.go
+++ b/pkg/edit/editor.go
@@ -56,27 +56,9 @@ func (ed *Editor) Edit(keyStream <-chan keyboard.KeyEvent, initBuffer string) (s
 			return "", e.Err
 		}
 
-		if keyboard.KeyEsc == e.Key && e.Rune == 98 {
-			// Alt + Left
-			fmt.Fprint(ed.output, ed.content.MoveToPrevWord())
-			continue
-		}
-
-		if keyboard.KeyEsc == e.Key && e.Rune == 102 {
-			// Alt + Right
-			fmt.Fprint(ed.output, ed.content.MoveToNextWord())
-			continue
-		}
-
 		if keyboard.KeyCtrlW == e.Key {
 			// Alt + Backspace
 			fmt.Fprint(ed.output, ed.content.DeleteToPrevWord())
-			continue
-		}
-
-		if keyboard.KeyEsc == e.Key && e.Rune == 100 {
-			// Alt + Delete
-			fmt.Fprint(ed.output, ed.content.DeleteToNextWord())
 			continue
 		}
 
@@ -86,7 +68,10 @@ func (ed *Editor) Edit(keyStream <-chan keyboard.KeyEvent, initBuffer string) (s
 		case keyboard.KeyCtrlS:
 			return ed.done()
 		case keyboard.KeyEsc:
-			fmt.Fprint(ed.output, ed.content.Clear())
+			if handleEscKey(e, ed) {
+				continue
+			}
+
 			return "", nil
 		case keyboard.KeyCtrlU:
 			fmt.Fprint(ed.output, ed.content.Clear())
@@ -142,6 +127,38 @@ func (ed *Editor) Edit(keyStream <-chan keyboard.KeyEvent, initBuffer string) (s
 	}
 
 	return "", fmt.Errorf("keyboard stream was unexpectably closed")
+}
+
+// handleEscKey processes keyboard events involving the Escape key and updates the editor state accordingly.
+// It takes a keyboard.KeyEvent `e` and an `Editor` pointer `ed`.
+// It returns a boolean indicating whether the event was handled (`true`) or not (`false`).
+//
+// The function handles the following key combinations:
+// - Alt + Left (`e.Rune == 98`): Moves the cursor to the previous word.
+// - Alt + Right (`e.Rune == 102`): Moves the cursor to the next word.
+// - Alt + Delete (`e.Rune == 100`): Deletes text up to the next word.
+// - Esc (`e.Rune == 0`): Clears the editor content and stops further processing.
+//
+// Any other key combination with the Escape key is ignored, and the function returns `true`.
+func handleEscKey(e keyboard.KeyEvent, ed *Editor) bool {
+	switch e.Rune {
+	case 98: //nolint:mnd // Alt + Left
+		fmt.Fprint(ed.output, ed.content.MoveToPrevWord())
+		return true
+	case 102: //nolint:mnd // Alt + Right
+		fmt.Fprint(ed.output, ed.content.MoveToNextWord())
+		return true
+	case 100: //nolint:mnd // Alt + Delete
+		fmt.Fprint(ed.output, ed.content.DeleteToNextWord())
+		return true
+	case 0:
+		// Esc
+		fmt.Fprint(ed.output, ed.content.Clear())
+		return false
+	default:
+		// Esc + any other key is ignored
+		return true
+	}
 }
 
 // done returns the current request and clears the editor content.

--- a/pkg/edit/editor_test.go
+++ b/pkg/edit/editor_test.go
@@ -220,3 +220,60 @@ func TestEditSpecialKeys(t *testing.T) {
 		}
 	}()
 }
+func TestHandleEscKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		keyEvent keyboard.KeyEvent
+		expected string
+		handled  bool
+	}{
+		{
+			name:     "Alt + Left",
+			keyEvent: keyboard.KeyEvent{Rune: 98},
+			expected: "",
+			handled:  true,
+		},
+		{
+			name:     "Alt + Right",
+			keyEvent: keyboard.KeyEvent{Rune: 102},
+			expected: "",
+			handled:  true,
+		},
+		{
+			name:     "Alt + Delete",
+			keyEvent: keyboard.KeyEvent{Rune: 100},
+			expected: "",
+			handled:  true,
+		},
+		{
+			name:     "Esc",
+			keyEvent: keyboard.KeyEvent{Rune: 0},
+			expected: "",
+			handled:  false,
+		},
+		{
+			name:     "Esc + any other key",
+			keyEvent: keyboard.KeyEvent{Rune: 1},
+			expected: "",
+			handled:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := new(bytes.Buffer)
+			editor := NewEditor(output, nil, false)
+
+			handled := handleEscKey(tt.keyEvent, editor)
+
+			if handled != tt.handled {
+				t.Errorf("Expected handled to be %v, got %v", tt.handled, handled)
+			}
+
+			outputStr := output.String()
+			if tt.expected != "" && !bytes.Contains(output.Bytes(), []byte(tt.expected)) {
+				t.Errorf("Expected output to contain %q, got %q", tt.expected, outputStr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement a function to delete text up to the previous word and integrate it with the Alt+Backspace key binding.