### PR TITLE
Rename cli package to core and refactor keyboard event handling

### DIFF
--- a/pkg/cmd/connect.go
+++ b/pkg/cmd/connect.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/ksysoev/wsget/pkg/cli"
 	"github.com/ksysoev/wsget/pkg/clierrors"
 	"github.com/ksysoev/wsget/pkg/command"
+	"github.com/ksysoev/wsget/pkg/core"
 	"github.com/ksysoev/wsget/pkg/ws"
 	"github.com/spf13/cobra"
 )
@@ -51,9 +51,9 @@ func runConnectCmd(ctx context.Context, args *flags, unnamedArgs []string) error
 
 	defer wsConn.Close()
 
-	input := cli.NewKeyboard()
+	input := core.NewKeyboard()
 
-	client, err := cli.NewCLI(wsConn, input, os.Stdout)
+	client, err := core.NewCLI(wsConn, input, os.Stdout)
 	if err != nil {
 		return fmt.Errorf("unable to start CLI: %w", err)
 	}
@@ -95,8 +95,8 @@ func validateArgs(wsURL string, args *flags) error {
 // It takes a single parameter args of type *flags which contains the command-line arguments.
 // It returns a pointer to cli.RunOptions and an error.
 // It returns an error if it fails to open the specified output file.
-func initRunOptions(args *flags) (opts *cli.RunOptions, err error) {
-	opts = &cli.RunOptions{}
+func initRunOptions(args *flags) (opts *core.RunOptions, err error) {
+	opts = &core.RunOptions{}
 
 	if args.outputFile != "" {
 		if opts.OutputFile, err = os.Create(args.outputFile); err != nil {

--- a/pkg/cmd/connect_test.go
+++ b/pkg/cmd/connect_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
-	"github.com/ksysoev/wsget/pkg/cli"
 	"github.com/ksysoev/wsget/pkg/command"
+	"github.com/ksysoev/wsget/pkg/core"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -111,7 +111,7 @@ func TestInitRunOptions(t *testing.T) {
 
 	tests := []struct {
 		args        *flags
-		expected    *cli.RunOptions
+		expected    *core.RunOptions
 		name        string
 		expectError bool
 	}{
@@ -122,7 +122,7 @@ func TestInitRunOptions(t *testing.T) {
 				request:      "test request",
 				waitResponse: -1,
 			},
-			expected: &cli.RunOptions{
+			expected: &core.RunOptions{
 				OutputFile: func() *os.File {
 					f, _ := os.Create(tmpDir + "/test_output.txt")
 					return f
@@ -147,7 +147,7 @@ func TestInitRunOptions(t *testing.T) {
 				request:      "test request",
 				waitResponse: 5,
 			},
-			expected: &cli.RunOptions{
+			expected: &core.RunOptions{
 				Commands: []command.Executer{
 					command.NewSend("test request"),
 					command.NewWaitForResp(5 * time.Second),
@@ -161,7 +161,7 @@ func TestInitRunOptions(t *testing.T) {
 			args: &flags{
 				inputFile: tmpDir + "/testfile.txt",
 			},
-			expected: &cli.RunOptions{
+			expected: &core.RunOptions{
 				Commands: []command.Executer{
 					command.NewInputFileCommand(tmpDir + "/testfile.txt"),
 				},
@@ -171,7 +171,7 @@ func TestInitRunOptions(t *testing.T) {
 		{
 			name: "Default Edit",
 			args: &flags{},
-			expected: &cli.RunOptions{
+			expected: &core.RunOptions{
 				Commands: []command.Executer{
 					command.NewEdit(""),
 				},

--- a/pkg/core/cli.go
+++ b/pkg/core/cli.go
@@ -1,4 +1,4 @@
-package cli
+package core
 
 import (
 	"fmt"

--- a/pkg/core/cli_test.go
+++ b/pkg/core/cli_test.go
@@ -1,4 +1,4 @@
-package cli
+package core
 
 import (
 	"context"

--- a/pkg/core/context.go
+++ b/pkg/core/context.go
@@ -3,28 +3,26 @@ package core
 import (
 	"io"
 
-	"github.com/eiannone/keyboard"
 	"github.com/ksysoev/wsget/pkg/command"
 	"github.com/ksysoev/wsget/pkg/formater"
 	"github.com/ksysoev/wsget/pkg/ws"
 )
 
 type ExecutionContext struct {
-	input      <-chan keyboard.KeyEvent
+	input      <-chan KeyEvent
 	cli        *CLI
 	outputFile io.Writer
 }
 
-func NewExecutionContext(cli *CLI, input <-chan keyboard.KeyEvent, outputFile io.Writer) *ExecutionContext {
+func NewExecutionContext(cli *CLI, outputFile io.Writer) *ExecutionContext {
 	return &ExecutionContext{
-		input:      input,
 		cli:        cli,
 		outputFile: outputFile,
 	}
 }
 
-func (ctx *ExecutionContext) Input() <-chan keyboard.KeyEvent {
-	return ctx.input
+func (ctx *ExecutionContext) Input() <-chan KeyEvent {
+	return ctx.cli.inputStream
 }
 
 func (ctx *ExecutionContext) OutputFile() io.Writer {

--- a/pkg/core/context.go
+++ b/pkg/core/context.go
@@ -1,4 +1,4 @@
-package cli
+package core
 
 import (
 	"io"

--- a/pkg/core/context_test.go
+++ b/pkg/core/context_test.go
@@ -1,4 +1,4 @@
-package cli
+package core
 
 import (
 	"bytes"

--- a/pkg/core/context_test.go
+++ b/pkg/core/context_test.go
@@ -3,22 +3,21 @@ package core
 import (
 	"bytes"
 	"testing"
-
-	"github.com/eiannone/keyboard"
 )
 
 func TestNewExecutionContext(t *testing.T) {
-	cli := &CLI{}
-	input := make(chan keyboard.KeyEvent)
+	cli := &CLI{
+		inputStream: make(chan KeyEvent),
+	}
 	outputFile := &bytes.Buffer{}
 
-	executionContext := NewExecutionContext(cli, input, outputFile)
+	executionContext := NewExecutionContext(cli, outputFile)
 
 	if executionContext.cli != cli {
 		t.Errorf("Unexpected CLI: %v", executionContext.cli)
 	}
 
-	if executionContext.input != input {
+	if executionContext.input != cli.inputStream {
 		t.Errorf("Unexpected input channel: %v", executionContext.input)
 	}
 
@@ -28,10 +27,9 @@ func TestNewExecutionContext(t *testing.T) {
 }
 func TestExecutionContext_Connection(t *testing.T) {
 	cli := &CLI{}
-	input := make(chan keyboard.KeyEvent)
 	outputFile := &bytes.Buffer{}
 
-	executionContext := NewExecutionContext(cli, input, outputFile)
+	executionContext := NewExecutionContext(cli, outputFile)
 
 	if executionContext.Connection() != cli.wsConn {
 		t.Errorf("Unexpected connection: %v", executionContext.Connection())
@@ -40,10 +38,9 @@ func TestExecutionContext_Connection(t *testing.T) {
 
 func TestExecutionContext_OutputFile(t *testing.T) {
 	cli := &CLI{}
-	input := make(chan keyboard.KeyEvent)
 	outputFile := &bytes.Buffer{}
 
-	executionContext := NewExecutionContext(cli, input, outputFile)
+	executionContext := NewExecutionContext(cli, outputFile)
 
 	if executionContext.OutputFile() != outputFile {
 		t.Errorf("Unexpected connection: %v", executionContext.OutputFile())
@@ -52,10 +49,9 @@ func TestExecutionContext_OutputFile(t *testing.T) {
 
 func TestExecutionContext_Output(t *testing.T) {
 	cli := &CLI{}
-	input := make(chan keyboard.KeyEvent)
 	outputFile := &bytes.Buffer{}
 
-	executionContext := NewExecutionContext(cli, input, outputFile)
+	executionContext := NewExecutionContext(cli, outputFile)
 
 	if executionContext.Output() != cli.output {
 		t.Errorf("Unexpected connection: %v", executionContext.Output())
@@ -64,10 +60,9 @@ func TestExecutionContext_Output(t *testing.T) {
 
 func TestExecutionContext_Formater(t *testing.T) {
 	cli := &CLI{}
-	input := make(chan keyboard.KeyEvent)
 	outputFile := &bytes.Buffer{}
 
-	executionContext := NewExecutionContext(cli, input, outputFile)
+	executionContext := NewExecutionContext(cli, outputFile)
 
 	if executionContext.Formater() != cli.formater {
 		t.Errorf("Unexpected connection: %v", executionContext.Formater())
@@ -76,10 +71,9 @@ func TestExecutionContext_Formater(t *testing.T) {
 
 func TestExecutionContext_RequestEditor(t *testing.T) {
 	cli := &CLI{}
-	input := make(chan keyboard.KeyEvent)
 	outputFile := &bytes.Buffer{}
 
-	executionContext := NewExecutionContext(cli, input, outputFile)
+	executionContext := NewExecutionContext(cli, outputFile)
 
 	if executionContext.RequestEditor() != cli.editor {
 		t.Errorf("Unexpected connection: %v", executionContext.RequestEditor())
@@ -88,10 +82,9 @@ func TestExecutionContext_RequestEditor(t *testing.T) {
 
 func TestExecutionContext_CmdEditor(t *testing.T) {
 	cli := &CLI{}
-	input := make(chan keyboard.KeyEvent)
 	outputFile := &bytes.Buffer{}
 
-	executionContext := NewExecutionContext(cli, input, outputFile)
+	executionContext := NewExecutionContext(cli, outputFile)
 
 	if executionContext.CmdEditor() != cli.cmdEditor {
 		t.Errorf("Unexpected connection: %v", executionContext.CmdEditor())
@@ -100,10 +93,9 @@ func TestExecutionContext_CmdEditor(t *testing.T) {
 
 func TestExecutionContext_Macro(t *testing.T) {
 	cli := &CLI{}
-	input := make(chan keyboard.KeyEvent)
 	outputFile := &bytes.Buffer{}
 
-	executionContext := NewExecutionContext(cli, input, outputFile)
+	executionContext := NewExecutionContext(cli, outputFile)
 
 	if executionContext.Macro() != cli.macro {
 		t.Errorf("Unexpected connection: %v", executionContext.Macro())
@@ -111,13 +103,14 @@ func TestExecutionContext_Macro(t *testing.T) {
 }
 
 func TestExecutionContext_Input(t *testing.T) {
-	cli := &CLI{}
-	input := make(chan keyboard.KeyEvent)
+	cli := &CLI{
+		inputStream: make(chan KeyEvent),
+	}
 	outputFile := &bytes.Buffer{}
 
-	executionContext := NewExecutionContext(cli, input, outputFile)
+	executionContext := NewExecutionContext(cli, outputFile)
 
-	if executionContext.Input() != input {
+	if executionContext.Input() != cli.inputStream {
 		t.Errorf("Unexpected connection: %v", executionContext.Input())
 	}
 }

--- a/pkg/core/input.go
+++ b/pkg/core/input.go
@@ -1,4 +1,4 @@
-package cli
+package core
 
 import "github.com/eiannone/keyboard"
 

--- a/pkg/core/key_events.go
+++ b/pkg/core/key_events.go
@@ -1,0 +1,28 @@
+package core
+
+type Key uint16
+
+type KeyEvent struct {
+	Key  Key
+	Rune rune
+}
+
+const (
+	KeyEsc        Key = 27
+	KeyCtrlC      Key = 3
+	KeyCtrlD      Key = 4
+	KeyEnter      Key = 13
+	KeyCtrlS      Key = 19
+	KeyCtrlU      Key = 21
+	KeySpace      Key = 32
+	KeyBackspace  Key = 8
+	MacBackspace2 Key = 127
+	KeyDelete     Key = 65522
+	KeyArrowLeft  Key = 65515
+	KeyArrowRight Key = 65517
+	KeyArrowUp    Key = 65514
+	KeyArrowDown  Key = 65516
+	KeyTab        Key = 9
+	KeyHome       Key = 65505
+	KeyEnd        Key = 65507
+)


### PR DESCRIPTION
Rename the `cli` package to `core` and refactor the usage of keyboard events within the core package to improve code organization and clarity.