### PR TITLE
Update Go version to 1.23.4 and adjust dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/wsget
 
-go 1.22
+go 1.23.4
 
 require (
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2
@@ -9,6 +9,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/sync v0.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -21,6 +22,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.27.0 // indirect
 )


### PR DESCRIPTION
**Description:**
- Upgraded the Go runtime version from 1.22 to 1.23.4 for better compatibility and performance.
- Moved "golang.org/x/sync" from indirect to direct dependencies.
- No functionality changes introduced.