### PR TITLE
Add configurable directory support for history and macros

### DIFF
--- a/pkg/cmd/connect.go
+++ b/pkg/cmd/connect.go
@@ -75,6 +75,7 @@ func runConnectCmd(ctx context.Context, args *flags, unnamedArgs []string) error
 		if err != nil {
 			return fmt.Errorf("fail to get current user: %s", err)
 		}
+
 		args.configDir = filepath.Join(currentUser.HomeDir, defaultConfigDir)
 	}
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -34,12 +34,12 @@ type flags struct {
 	request      string
 	outputFile   string
 	inputFile    string
+	configDir    string
 	headers      []string
 	maxMsgSize   int64
 	waitResponse int
 	insecure     bool
 	verbose      bool
-	configDir    string
 }
 
 // InitCommands initializes and returns a new cobra.Command for the wsget tool.

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"cmp"
+	"os"
+
 	"github.com/ksysoev/wsget/pkg/ws"
 	"github.com/spf13/cobra"
 )
@@ -36,6 +39,7 @@ type flags struct {
 	waitResponse int
 	insecure     bool
 	verbose      bool
+	configDir    string
 }
 
 // InitCommands initializes and returns a new cobra.Command for the wsget tool.
@@ -55,6 +59,7 @@ func InitCommands(version string) *cobra.Command {
 		RunE:       createConnectRunner(args),
 	}
 
+	cmd.Flags().StringVarP(&args.configDir, "config-dir", "c", "", "Configuration directory for storing history and macros")
 	cmd.Flags().BoolVarP(&args.insecure, "insecure", "k", false, "Skip SSL certificate verification")
 	cmd.Flags().StringVarP(&args.request, "request", "r", "", "WebSocket request that will be sent to the server")
 	cmd.Flags().StringVarP(&args.outputFile, "output", "o", "", "Output file for saving all request and responses")
@@ -63,6 +68,8 @@ func InitCommands(version string) *cobra.Command {
 	cmd.Flags().StringVarP(&args.inputFile, "input", "i", "", "Input YAML file with list of requests to send to the server")
 	cmd.Flags().BoolVarP(&args.verbose, "verbose", "v", false, "Verbose output")
 	cmd.Flags().Int64VarP(&args.maxMsgSize, "max-size", "s", ws.DefaultMaxMessageSize, "Maximum message size in bytes, non-positive value will be ignored and default value will be used")
+
+	args.configDir = cmp.Or(args.configDir, os.Getenv("WSGET_CONFIG_DIR"))
 
 	return cmd
 }


### PR DESCRIPTION
**Description:**
- Updated the program to include a `--config-dir` flag for specifying a custom configuration directory.
- Provides possibility to define configuration directory with environment variable as well
- Default directory logic now involves `$HOME/.wsget` when the flag is not provided or empty.