### PR TITLE
Add Ctrl+L support for clearing terminal and displaying welcome message

### DIFF
--- a/pkg/core/cli.go
+++ b/pkg/core/cli.go
@@ -14,6 +14,9 @@ const (
 
 	HideCursor = "\x1b[?25l"
 	ShowCursor = "\x1b[?25h"
+
+	ClearTerminal = "\u001B[H\u001B[2J"
+	WelcomMessage = "Use Enter to input request and send it, Ctrl+C to exit"
 )
 
 var (
@@ -119,7 +122,7 @@ func (c *CLI) Run(ctx context.Context, opts RunOptions) error {
 
 	c.hideCursor()
 
-	_, _ = fmt.Fprintln(c.output, "Use Enter to input request and send it, Ctrl+C to exit")
+	_, _ = fmt.Fprintln(c.output, WelcomMessage)
 
 	for _, cmd := range opts.Commands {
 		c.commands <- cmd
@@ -147,6 +150,8 @@ func (c *CLI) Run(ctx context.Context, opts RunOptions) error {
 				}
 
 				c.commands <- cmd
+			case KeyCtrlL:
+				_, _ = fmt.Fprintln(c.output, ClearTerminal+WelcomMessage)
 			case KeyEnter:
 				cmd, err := c.cmdFactory.Create("edit")
 				if err != nil {

--- a/pkg/core/command/commands.go
+++ b/pkg/core/command/commands.go
@@ -31,20 +31,8 @@ func NewEdit(content string) *Edit {
 
 // Execute executes the edit command and returns a Send command id editing was successful or an error in other case.
 func (c *Edit) Execute(exCtx core.ExecutionContext) (core.Executer, error) {
-	if err := exCtx.Print("->", color.FgGreen); err != nil {
-		return nil, err
-	}
-
-	if err := exCtx.Print("\n" + ShowCursor); err != nil {
-		return nil, err
-	}
-
 	req, err := exCtx.EditorMode(c.content)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := exCtx.Print(LineUp + LineClear + HideCursor); err != nil {
 		return nil, err
 	}
 

--- a/pkg/core/command/commands.go
+++ b/pkg/core/command/commands.go
@@ -177,16 +177,8 @@ func NewCmdEdit() *CmdEdit {
 // Execute executes the CmdEdit and returns a core.Executer and an error.
 // It prompts the user to edit a command and returns the corresponding Command object.
 func (c *CmdEdit) Execute(exCtx core.ExecutionContext) (core.Executer, error) {
-	if err := exCtx.Print(":" + ShowCursor); err != nil {
-		return nil, err
-	}
-
 	rawCmd, err := exCtx.CommandMode("")
 	if err != nil {
-		return nil, err
-	}
-
-	if err := exCtx.Print(LineClear + "\r" + HideCursor); err != nil {
 		return nil, err
 	}
 

--- a/pkg/core/edit/content.go
+++ b/pkg/core/edit/content.go
@@ -474,3 +474,31 @@ func (c *Content) GetCurrentWord() string {
 
 	return string(c.text[start:c.pos])
 }
+
+func (c *Content) GetPosition() int {
+	return c.pos
+}
+
+func (c *Content) MoveToPosition(pos int) string {
+	if pos < 0 {
+		pos = 0
+	}
+
+	if pos > len(c.text) {
+		pos = len(c.text)
+	}
+
+	output := ""
+
+	if pos < c.pos {
+		for c.pos > pos {
+			output += c.MovePositionLeft()
+		}
+	} else if pos > c.pos {
+		for c.pos < pos {
+			output += c.MovePositionRight()
+		}
+	}
+
+	return output
+}

--- a/pkg/core/edit/content.go
+++ b/pkg/core/edit/content.go
@@ -475,10 +475,17 @@ func (c *Content) GetCurrentWord() string {
 	return string(c.text[start:c.pos])
 }
 
+// GetPosition retrieves the current position value of the Content.
+// It takes no parameters.
+// It returns an int representing the current position.
 func (c *Content) GetPosition() int {
 	return c.pos
 }
 
+// MoveToPosition moves the current position to the specified index and returns the resultant output string.
+// It takes pos of type int, which is the target position relative to the content length.
+// It returns a string detailing the changes made while adjusting the position.
+// If pos is less than 0, it defaults to 0. If pos exceeds the content length, it defaults to the content's length.
 func (c *Content) MoveToPosition(pos int) string {
 	if pos < 0 {
 		pos = 0

--- a/pkg/core/edit/content_test.go
+++ b/pkg/core/edit/content_test.go
@@ -12,7 +12,7 @@ func TestNewContent(t *testing.T) {
 		return
 	}
 
-	if c.pos != 0 {
+	if c.GetPosition() != 0 {
 		t.Errorf("NewContent() returned Content with pos %d, expected 0", c.pos)
 	}
 
@@ -1311,6 +1311,70 @@ func TestContent_GetCurrentWord(t *testing.T) {
 
 			if got := c.GetCurrentWord(); got != tt.expected {
 				t.Errorf("GetCurrentWord() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContent_MoveToPosition(t *testing.T) {
+	tests := []struct {
+		content     *Content
+		name        string
+		expected    string
+		pos         int
+		expectedPos int
+	}{
+		{
+			name: "move to position within bounds",
+			content: &Content{
+				text: []rune("hello world"),
+				pos:  0,
+			},
+			pos:         5,
+			expected:    "hello",
+			expectedPos: 5,
+		},
+		{
+			name: "move to position out of bounds (negative)",
+			content: &Content{
+				text: []rune("hello world"),
+				pos:  5,
+			},
+			pos:         -1,
+			expected:    "\b\b\b\b\b",
+			expectedPos: 0,
+		},
+		{
+			name: "move to position out of bounds (exceeds length)",
+			content: &Content{
+				text: []rune("hello world"),
+				pos:  5,
+			},
+			pos:         20,
+			expected:    " world",
+			expectedPos: 11,
+		},
+		{
+			name: "move to same position",
+			content: &Content{
+				text: []rune("hello world"),
+				pos:  5,
+			},
+			pos:         5,
+			expected:    "",
+			expectedPos: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.content.MoveToPosition(tt.pos)
+			if actual != tt.expected {
+				t.Errorf("expected %q, but got %q", tt.expected, actual)
+			}
+
+			if tt.content.pos != tt.expectedPos {
+				t.Errorf("expected position %d, but got %d", tt.expectedPos, tt.content.pos)
 			}
 		})
 	}

--- a/pkg/core/edit/editor.go
+++ b/pkg/core/edit/editor.go
@@ -175,6 +175,25 @@ func (ed *Editor) handleKey(e core.KeyEvent) (next bool, res string, err error) 
 		_, _ = fmt.Fprint(ed.output, ed.content.MoveToRowStart())
 	case core.KeyEnd:
 		_, _ = fmt.Fprint(ed.output, ed.content.MoveToRowEnd())
+	case core.KeyCtrlL:
+		content := ed.content.String()
+		pos := ed.content.GetPosition()
+
+		if _, err := fmt.Fprint(ed.output, ed.content.Clear()+core.ClearTerminal); err != nil {
+			return false, "", fmt.Errorf("failed to clear terminal: %w", err)
+		}
+
+		if err := ed.onOpen(ed.output); err != nil {
+			return false, "", fmt.Errorf("failed to execute open hook: %w", err)
+		}
+
+		if _, err := fmt.Fprint(ed.output, ed.content.ReplaceText(content)); err != nil {
+			return false, "", fmt.Errorf("failed to write content: %w", err)
+		}
+
+		if _, err := fmt.Fprint(ed.output, ed.content.MoveToPosition(pos)); err != nil {
+			return false, "", fmt.Errorf("failed to move to position: %w", err)
+		}
 	default:
 		if e.Key > 0 {
 			return true, "", nil

--- a/pkg/core/edit/editor.go
+++ b/pkg/core/edit/editor.go
@@ -26,16 +26,16 @@ const (
 type Option func(*Editor)
 
 type Editor struct {
-	input           <-chan core.KeyEvent
-	history         HistoryRepo
-	content         *Content
-	output          io.Writer
 	prevPressedTime time.Time
+	history         HistoryRepo
+	output          io.Writer
+	input           <-chan core.KeyEvent
+	content         *Content
+	onOpen          func(io.Writer) error
+	onClose         func(io.Writer) error
 	buffer          []rune
 	pos             int
 	isSingleLine    bool
-	onOpen          func(io.Writer) error
-	onClose         func(io.Writer) error
 }
 
 // NewEditor initializes a new instance of Editor for text editing tasks.
@@ -78,7 +78,9 @@ func (ed *Editor) Edit(ctx context.Context, initBuffer string) (res string, err 
 	}
 
 	defer func() {
-		err = ed.onClose(ed.output)
+		if closeErr := ed.onClose(ed.output); err == nil {
+			err = closeErr
+		}
 	}()
 
 	ed.history.ResetPosition()

--- a/pkg/core/edit/editor_test.go
+++ b/pkg/core/edit/editor_test.go
@@ -72,6 +72,45 @@ func TestEdit(t *testing.T) {
 	}
 }
 
+func TestEditor_Edit_FailOpenHook(t *testing.T) {
+	history := NewMockHistoryRepo(t)
+
+	editor := NewEditor(io.Discard, history, false, WithOpenHook(func(_ io.Writer) error {
+		return assert.AnError
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req, err := editor.Edit(ctx, "")
+
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Empty(t, req)
+}
+
+func TestEditor_Edit_FailCloseHook(t *testing.T) {
+	history := NewMockHistoryRepo(t)
+	history.EXPECT().ResetPosition()
+
+	editor := NewEditor(io.Discard, history, true, WithCloseHook(func(_ io.Writer) error {
+		return assert.AnError
+	}))
+
+	keyStream := make(chan core.KeyEvent, 1)
+	defer close(keyStream)
+
+	editor.SetInput(keyStream)
+
+	go func() {
+		keyStream <- core.KeyEvent{Key: core.KeyEnter}
+	}()
+
+	req, err := editor.Edit(context.Background(), "")
+
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Empty(t, req)
+}
+
 func TestEditInterrupted(t *testing.T) {
 	history := NewMockHistoryRepo(t)
 	history.EXPECT().ResetPosition()
@@ -476,6 +515,13 @@ func TestEditorHandleKey(t *testing.T) {
 		{
 			name:         "Alt + Left Key",
 			keyEvent:     core.KeyEvent{Key: core.KeyEsc, Rune: 98},
+			expectedNext: true,
+			expectedRes:  "",
+			expectedErr:  nil,
+		},
+		{
+			name:         "Ctrl + L",
+			keyEvent:     core.KeyEvent{Key: core.KeyCtrlL},
 			expectedNext: true,
 			expectedRes:  "",
 			expectedErr:  nil,

--- a/pkg/core/edit/multimode.go
+++ b/pkg/core/edit/multimode.go
@@ -2,9 +2,15 @@ package edit
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/ksysoev/wsget/pkg/core"
+)
+
+const (
+	HideCursor = "\x1b[?25l"
+	ShowCursor = "\x1b[?25h"
 )
 
 type MultiMode struct {
@@ -16,7 +22,19 @@ type MultiMode struct {
 // It takes an io.Writer, two HistoryRepo instances for request and command histories, and an optional Dictionary.
 // It returns a pointer to the created MultiMode, setting up command and edit modes appropriately.
 func NewMultiMode(output io.Writer, reqHistory, cmdHistory HistoryRepo) *MultiMode {
-	commandMode := NewEditor(output, cmdHistory, true)
+	commandMode := NewEditor(
+		output,
+		cmdHistory,
+		true,
+		WithOpenHook(func(w io.Writer) error {
+			_, err := fmt.Fprintf(w, ":"+ShowCursor)
+			return err
+		}),
+		WithCloseHook(func(w io.Writer) error {
+			_, err := fmt.Fprintf(w, LineClear+"\r"+HideCursor)
+			return err
+		}),
+	)
 
 	return &MultiMode{
 		commandMode: commandMode,

--- a/pkg/core/edit/multimode_test.go
+++ b/pkg/core/edit/multimode_test.go
@@ -2,7 +2,9 @@ package edit
 
 import (
 	"context"
+	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/ksysoev/wsget/pkg/core"
@@ -63,4 +65,170 @@ func TestMultiMode_Edit(t *testing.T) {
 	result, err := multiMode.Edit(context.Background(), "edit")
 	assert.NoError(t, err)
 	assert.Equal(t, "edit", result)
+}
+
+type failingWriter struct{}
+
+func (f failingWriter) Write(_ []byte) (n int, err error) {
+	return 0, errors.New("failed to write")
+}
+
+func TestEditorOpenHook(t *testing.T) {
+	tests := []struct {
+		name           string
+		writer         io.Writer
+		expectedOutput string
+		expectedError  error
+	}{
+		{
+			name:           "Success with valid writer",
+			writer:         &strings.Builder{},
+			expectedOutput: "->\n\x1b[?25h", // Output contains the "->" and the ANSI escape ShowCursor
+			expectedError:  nil,
+		},
+		{
+			name:           "Error on colored write",
+			writer:         failingWriter{},
+			expectedOutput: "",
+			expectedError:  errors.New("failed to write"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a writer for capturing output
+			builder, ok := tt.writer.(*strings.Builder)
+
+			// Execute the function
+			err := editorOpenHook(tt.writer)
+
+			// Assert expected outcomes
+			assert.Equal(t, tt.expectedError, err)
+
+			// Check writer contents for successful cases
+			if ok {
+				assert.Equal(t, tt.expectedOutput, builder.String())
+			}
+		})
+	}
+}
+
+func TestEditorCloseHook(t *testing.T) {
+	tests := []struct {
+		name           string
+		writer         io.Writer
+		expectedOutput string
+		expectedError  error
+	}{
+		{
+			name:           "Success with valid writer",
+			writer:         &strings.Builder{},
+			expectedOutput: LineUp + LineClear + HideCursor, // Output contains the ANSI escape sequences for cursor movement and hiding
+			expectedError:  nil,
+		},
+		{
+			name:           "Error with failing writer",
+			writer:         failingWriter{},
+			expectedOutput: "",
+			expectedError:  errors.New("failed to write"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a writer for capturing output
+			builder, ok := tt.writer.(*strings.Builder)
+
+			// Execute the function
+			err := editorCloseHook(tt.writer)
+
+			// Assert expected outcomes
+			assert.Equal(t, tt.expectedError, err)
+
+			// Check writer contents for successful cases
+			if ok {
+				assert.Equal(t, tt.expectedOutput, builder.String())
+			}
+		})
+	}
+}
+
+func TestCmdEditorOpenHook(t *testing.T) {
+	tests := []struct {
+		name           string
+		writer         io.Writer
+		expectedOutput string
+		expectedError  error
+	}{
+		{
+			name:           "Success with valid writer",
+			writer:         &strings.Builder{},
+			expectedOutput: ":" + ShowCursor, // ':' followed by ShowCursor
+			expectedError:  nil,
+		},
+		{
+			name:           "Error with failing writer",
+			writer:         failingWriter{},
+			expectedOutput: "",
+			expectedError:  errors.New("failed to write"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a writer for capturing output
+			builder, ok := tt.writer.(*strings.Builder)
+
+			// Execute the function
+			err := cmdEditorOpenHook(tt.writer)
+
+			// Assert expected outcomes
+			assert.Equal(t, tt.expectedError, err)
+
+			// Check writer contents for successful cases
+			if ok {
+				assert.Equal(t, tt.expectedOutput, builder.String())
+			}
+		})
+	}
+}
+
+func TestCmdEditorCloseHook(t *testing.T) {
+	tests := []struct {
+		name           string
+		writer         io.Writer
+		expectedOutput string
+		expectedError  error
+	}{
+		{
+			name:           "Success with valid writer",
+			writer:         &strings.Builder{},
+			expectedOutput: LineClear + "\r" + HideCursor, // Verify correct output with valid writer
+			expectedError:  nil,
+		},
+		{
+			name:           "Error with failing writer",
+			writer:         failingWriter{},
+			expectedOutput: "",
+			expectedError:  errors.New("failed to write"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a writer for capturing output
+			builder, ok := tt.writer.(*strings.Builder)
+
+			// Execute the function
+			err := cmdEditorCloseHook(tt.writer)
+
+			// Assert expected outcomes
+			assert.Equal(t, tt.expectedError, err)
+
+			// Check writer contents for successful cases
+			if ok {
+				assert.Equal(t, tt.expectedOutput, builder.String())
+			}
+		})
+	}
 }

--- a/pkg/core/edit/multimode_test.go
+++ b/pkg/core/edit/multimode_test.go
@@ -75,10 +75,10 @@ func (f failingWriter) Write(_ []byte) (n int, err error) {
 
 func TestEditorOpenHook(t *testing.T) {
 	tests := []struct {
-		name           string
 		writer         io.Writer
-		expectedOutput string
 		expectedError  error
+		name           string
+		expectedOutput string
 	}{
 		{
 			name:           "Success with valid writer",
@@ -115,10 +115,10 @@ func TestEditorOpenHook(t *testing.T) {
 
 func TestEditorCloseHook(t *testing.T) {
 	tests := []struct {
-		name           string
 		writer         io.Writer
-		expectedOutput string
 		expectedError  error
+		name           string
+		expectedOutput string
 	}{
 		{
 			name:           "Success with valid writer",
@@ -155,10 +155,10 @@ func TestEditorCloseHook(t *testing.T) {
 
 func TestCmdEditorOpenHook(t *testing.T) {
 	tests := []struct {
-		name           string
 		writer         io.Writer
-		expectedOutput string
 		expectedError  error
+		name           string
+		expectedOutput string
 	}{
 		{
 			name:           "Success with valid writer",
@@ -195,10 +195,10 @@ func TestCmdEditorOpenHook(t *testing.T) {
 
 func TestCmdEditorCloseHook(t *testing.T) {
 	tests := []struct {
-		name           string
 		writer         io.Writer
-		expectedOutput string
 		expectedError  error
+		name           string
+		expectedOutput string
 	}{
 		{
 			name:           "Success with valid writer",

--- a/pkg/core/key_events.go
+++ b/pkg/core/key_events.go
@@ -26,4 +26,5 @@ const (
 	KeyTab          Key = 9
 	KeyHome         Key = 65505
 	KeyEnd          Key = 65507
+	KeyCtrlL        Key = 12
 )


### PR DESCRIPTION

This pull request introduces a new key event `KeyCtrlL` to clear the terminal screen and show the welcome message. The welcome message is refactored into a constant for improved code readability and user experience. This enhancement streamlines the usage of the welcome message throughout the codebase.