### PR TITLE
Set draft mode for releases in Goreleaser configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ checksum:
 changelog:
   sort: asc
 release:
+  draft: true
   github:
     owner: ksysoev
     name: wsget


### PR DESCRIPTION
**Description:**

Updated Goreleaser configuration to enable draft mode for GitHub releases, allowing for review and adjustment before publishing.