### PR TITLE
Add macro download subcommand functionality to CLI

### DIFF
--- a/pkg/cmd/connect.go
+++ b/pkg/cmd/connect.go
@@ -103,12 +103,16 @@ func runConnectCmd(ctx context.Context, args *flags, unnamedArgs []string) error
 		return fmt.Errorf("fail to load macro: %s", err)
 	}
 
+	var cmdFactory *command2.Factory
+
 	if macroRepo != nil {
 		cmdHistory.AddWordsToIndex(macroRepo.GetNames())
+		cmdFactory = command2.NewFactory(macroRepo)
+	} else {
+		cmdFactory = command2.NewFactory(nil)
 	}
 
 	editor := edit.NewMultiMode(os.Stdout, reqHistory, cmdHistory)
-	cmdFactory := command2.NewFactory(macroRepo)
 
 	client := core.NewCLI(cmdFactory, wsConn, os.Stdout, editor, formater.NewFormat())
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -88,10 +88,10 @@ func initMacroDownloadCommand(args *flags) *cobra.Command {
 		Use:   "download [flags] <url>",
 		Short: "Download a macro file from provided URL",
 		Args:  cobra.ExactArgs(1),
-		RunE:  createMacroDownloadRunner(args, fileName),
+		RunE:  createMacroDownloadRunner(args, &fileName),
 	}
 
-	cmd.Flags().StringVarP(&fileName, "name", "n", "", "File name to save the macro")
+	cmd.Flags().StringVarP(&fileName, "name", "n", "default", "File name to save the macro")
 
 	return cmd
 }

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -59,9 +59,8 @@ func InitCommands(version string) *cobra.Command {
 		RunE:       createConnectRunner(args),
 	}
 
-	cmd.AddCommand(initMacroDownloadCommand())
+	cmd.PersistentFlags().StringVarP(&args.configDir, "config-dir", "c", "", "Configuration directory for storing history and macros")
 
-	cmd.Flags().StringVarP(&args.configDir, "config-dir", "c", "", "Configuration directory for storing history and macros")
 	cmd.Flags().BoolVarP(&args.insecure, "insecure", "k", false, "Skip SSL certificate verification")
 	cmd.Flags().StringVarP(&args.request, "request", "r", "", "WebSocket request that will be sent to the server")
 	cmd.Flags().StringVarP(&args.outputFile, "output", "o", "", "Output file for saving all request and responses")
@@ -73,6 +72,8 @@ func InitCommands(version string) *cobra.Command {
 
 	args.configDir = cmp.Or(args.configDir, os.Getenv("WSGET_CONFIG_DIR"))
 
+	cmd.AddCommand(initMacroDownloadCommand(args))
+
 	return cmd
 }
 
@@ -80,14 +81,14 @@ func InitCommands(version string) *cobra.Command {
 // It takes args of type flags to configure the command's behavior.
 // It returns a pointer to a Cobra command configured with necessary flags and options.
 // It returns an error during execution if the URL is invalid or there is an issue during the file download.
-func initMacroDownloadCommand() *cobra.Command {
+func initMacroDownloadCommand(args *flags) *cobra.Command {
 	var fileName string
 
 	cmd := &cobra.Command{
 		Use:   "download [flags] <url>",
 		Short: "Download a macro file from provided URL",
 		Args:  cobra.ExactArgs(1),
-		RunE:  createMacroDownloadRunner(fileName),
+		RunE:  createMacroDownloadRunner(args, fileName),
 	}
 
 	cmd.Flags().StringVarP(&fileName, "name", "n", "", "File name to save the macro")

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -59,6 +59,8 @@ func InitCommands(version string) *cobra.Command {
 		RunE:       createConnectRunner(args),
 	}
 
+	cmd.AddCommand(initMacroDownloadCommand())
+
 	cmd.Flags().StringVarP(&args.configDir, "config-dir", "c", "", "Configuration directory for storing history and macros")
 	cmd.Flags().BoolVarP(&args.insecure, "insecure", "k", false, "Skip SSL certificate verification")
 	cmd.Flags().StringVarP(&args.request, "request", "r", "", "WebSocket request that will be sent to the server")
@@ -70,6 +72,25 @@ func InitCommands(version string) *cobra.Command {
 	cmd.Flags().Int64VarP(&args.maxMsgSize, "max-size", "s", ws.DefaultMaxMessageSize, "Maximum message size in bytes, non-positive value will be ignored and default value will be used")
 
 	args.configDir = cmp.Or(args.configDir, os.Getenv("WSGET_CONFIG_DIR"))
+
+	return cmd
+}
+
+// initMacroDownloadCommand initializes a Cobra command for downloading a macro file from a URL.
+// It takes args of type flags to configure the command's behavior.
+// It returns a pointer to a Cobra command configured with necessary flags and options.
+// It returns an error during execution if the URL is invalid or there is an issue during the file download.
+func initMacroDownloadCommand() *cobra.Command {
+	var fileName string
+
+	cmd := &cobra.Command{
+		Use:   "download [flags] <url>",
+		Short: "Download a macro file from provided URL",
+		Args:  cobra.ExactArgs(1),
+		RunE:  createMacroDownloadRunner(fileName),
+	}
+
+	cmd.Flags().StringVarP(&fileName, "name", "n", "", "File name to save the macro")
 
 	return cmd
 }

--- a/pkg/cmd/macro.go
+++ b/pkg/cmd/macro.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
+	"github.com/ksysoev/wsget/pkg/repo/macro"
 	"github.com/spf13/cobra"
 )
 
@@ -11,12 +13,23 @@ import (
 // It takes filename of type string which specifies the name of the file to save the macro.
 // It returns a function that accepts a Cobra command and its arguments, and executes the macro download logic.
 // It returns an error if the macro download command encounters an issue during execution.
-func createMacroDownloadRunner(filename string) func(cmd *cobra.Command, args []string) error {
+func createMacroDownloadRunner(args *flags, filename string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, unnamedArgs []string) error {
-		return runMacroDownloadCommand(cmd.Context(), filename, unnamedArgs)
+		return runMacroDownloadCommand(cmd.Context(), args, filename, unnamedArgs)
 	}
 }
 
-func runMacroDownloadCommand(_ context.Context, _ string, _ []string) error {
-	return fmt.Errorf("not implemented")
+func runMacroDownloadCommand(_ context.Context, args *flags, name string, unnamedArgs []string) error {
+	url := unnamedArgs[0]
+	if url == "" {
+		return fmt.Errorf("macro URL is required")
+	}
+
+	path := filepath.Join(args.configDir, macroDir, name)
+
+	macroRepo := macro.NewMacro(nil)
+
+	err := macroRepo.Download(path, url)
+
+	return fmt.Errorf("fail to download macro: %w", err)
 }

--- a/pkg/cmd/macro.go
+++ b/pkg/cmd/macro.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// createMacroDownloadRunner creates a runner function for executing a macro download command.
+// It takes filename of type string which specifies the name of the file to save the macro.
+// It returns a function that accepts a Cobra command and its arguments, and executes the macro download logic.
+// It returns an error if the macro download command encounters an issue during execution.
+func createMacroDownloadRunner(filename string) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, unnamedArgs []string) error {
+		return runMacroDownloadCommand(cmd.Context(), filename, unnamedArgs)
+	}
+}
+
+func runMacroDownloadCommand(_ context.Context, _ string, _ []string) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/cmd/macro.go
+++ b/pkg/cmd/macro.go
@@ -20,6 +20,10 @@ func createMacroDownloadRunner(args *flags, filename *string) func(cmd *cobra.Co
 	}
 }
 
+// runMacroDownloadCommand downloads a macro configuration file from a given URL and saves it to a specified path.
+// It takes a context, args of type *flags, name of type *string, and unnamedArgs of type []string.
+// It returns an error if the URL is missing, the current user cannot be retrieved, the file creation fails,
+// or the macro download encounters an issue such as invalid YAML or unsupported macro version.
 func runMacroDownloadCommand(_ context.Context, args *flags, name *string, unnamedArgs []string) error {
 	url := unnamedArgs[0]
 	if url == "" {
@@ -37,9 +41,5 @@ func runMacroDownloadCommand(_ context.Context, args *flags, name *string, unnam
 
 	path := filepath.Join(args.configDir, macroDir, *name)
 
-	if err := macro.Download(path, url); err != nil {
-		return fmt.Errorf("fail to download macro: %w", err)
-	}
-
-	return nil
+	return macro.Download(path, url)
 }

--- a/pkg/cmd/macro.go
+++ b/pkg/cmd/macro.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os/user"
 	"path/filepath"
 
 	"github.com/ksysoev/wsget/pkg/repo/macro"
@@ -13,23 +14,34 @@ import (
 // It takes filename of type string which specifies the name of the file to save the macro.
 // It returns a function that accepts a Cobra command and its arguments, and executes the macro download logic.
 // It returns an error if the macro download command encounters an issue during execution.
-func createMacroDownloadRunner(args *flags, filename string) func(cmd *cobra.Command, args []string) error {
+func createMacroDownloadRunner(args *flags, filename *string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, unnamedArgs []string) error {
 		return runMacroDownloadCommand(cmd.Context(), args, filename, unnamedArgs)
 	}
 }
 
-func runMacroDownloadCommand(_ context.Context, args *flags, name string, unnamedArgs []string) error {
+func runMacroDownloadCommand(_ context.Context, args *flags, name *string, unnamedArgs []string) error {
 	url := unnamedArgs[0]
 	if url == "" {
 		return fmt.Errorf("macro URL is required")
 	}
 
-	path := filepath.Join(args.configDir, macroDir, name)
+	if args.configDir == "" {
+		currentUser, err := user.Current()
+		if err != nil {
+			return fmt.Errorf("fail to get current user: %s", err)
+		}
+
+		args.configDir = filepath.Join(currentUser.HomeDir, defaultConfigDir)
+	}
+
+	path := filepath.Join(args.configDir, macroDir, *name)
 
 	macroRepo := macro.NewMacro(nil)
 
-	err := macroRepo.Download(path, url)
+	if err := macroRepo.Download(path, url); err != nil {
+		return fmt.Errorf("fail to download macro: %w", err)
+	}
 
-	return fmt.Errorf("fail to download macro: %w", err)
+	return nil
 }

--- a/pkg/cmd/macro.go
+++ b/pkg/cmd/macro.go
@@ -37,9 +37,7 @@ func runMacroDownloadCommand(_ context.Context, args *flags, name *string, unnam
 
 	path := filepath.Join(args.configDir, macroDir, *name)
 
-	macroRepo := macro.NewMacro(nil)
-
-	if err := macroRepo.Download(path, url); err != nil {
+	if err := macro.Download(path, url); err != nil {
 		return fmt.Errorf("fail to download macro: %w", err)
 	}
 

--- a/pkg/cmd/macro_test.go
+++ b/pkg/cmd/macro_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunMacroDownloadCommand_NoUrl(t *testing.T) {
+	args := &flags{}
+	name := "test"
+	unnamedArgs := []string{""}
+
+	err := runMacroDownloadCommand(context.Background(), args, &name, unnamedArgs)
+	assert.ErrorContains(t, err, "macro URL is required")
+}
+
+func TestRunMacroDownloadCommand_NoConfigDir(t *testing.T) {
+	args := &flags{}
+	name := "test"
+	unnamedArgs := []string{"http://localhost:0"}
+
+	err := runMacroDownloadCommand(context.Background(), args, &name, unnamedArgs)
+	assert.ErrorContains(t, err, "connect: can't assign requested address")
+}
+
+func TestRunMacroDownloadCommand_FailToDownload(t *testing.T) {
+	args := &flags{configDir: "testdata"}
+	name := "test"
+	unnamedArgs := []string{"http://localhost:0"}
+
+	err := runMacroDownloadCommand(context.Background(), args, &name, unnamedArgs)
+	assert.ErrorContains(t, err, "connect: can't assign requested address")
+}
+
+func TestRunMacroDownloadCommand(t *testing.T) {
+	// Act
+	runner := createMacroDownloadRunner(&flags{}, nil)
+	err := runner(&cobra.Command{}, []string{""})
+
+	// Assert
+	assert.ErrorContains(t, err, "macro URL is required")
+}

--- a/pkg/cmd/macro_test.go
+++ b/pkg/cmd/macro_test.go
@@ -20,19 +20,19 @@ func TestRunMacroDownloadCommand_NoUrl(t *testing.T) {
 func TestRunMacroDownloadCommand_NoConfigDir(t *testing.T) {
 	args := &flags{}
 	name := "test"
-	unnamedArgs := []string{"http://localhost:0"}
+	unnamedArgs := []string{"http://localhost:9999"}
 
 	err := runMacroDownloadCommand(context.Background(), args, &name, unnamedArgs)
-	assert.ErrorContains(t, err, "connect: can't assign requested address")
+	assert.ErrorContains(t, err, "connect: connection refused")
 }
 
 func TestRunMacroDownloadCommand_FailToDownload(t *testing.T) {
 	args := &flags{configDir: "testdata"}
 	name := "test"
-	unnamedArgs := []string{"http://localhost:0"}
+	unnamedArgs := []string{"http://localhost:9999"}
 
 	err := runMacroDownloadCommand(context.Background(), args, &name, unnamedArgs)
-	assert.ErrorContains(t, err, "connect: can't assign requested address")
+	assert.ErrorContains(t, err, "connect: connection refused")
 }
 
 func TestRunMacroDownloadCommand(t *testing.T) {

--- a/pkg/core/command/macro.go
+++ b/pkg/core/command/macro.go
@@ -1,26 +1,25 @@
-package macro
+package command
 
 import (
 	"bytes"
 	"text/template"
 
 	"github.com/ksysoev/wsget/pkg/core"
-	"github.com/ksysoev/wsget/pkg/core/command"
 )
 
 type Templates struct {
 	list []*template.Template
 }
 
-// NewMacroTemplates creates a new Templates instance by parsing a list of string templates.
+// NewMacro creates a new Templates instance by parsing a list of string templates.
 // It takes a parameter templates of type []string, representing raw string templates.
 // It returns a pointer to a Templates instance populated with parsed templates.
 // It returns an error if any of the provided templates fail to parse.
-func NewMacroTemplates(templates []string) (*Templates, error) {
+func NewMacro(rawTemplates []string) (*Templates, error) {
 	tmpls := &Templates{}
-	tmpls.list = make([]*template.Template, len(templates))
+	tmpls.list = make([]*template.Template, len(rawTemplates))
 
-	for i, rawTempl := range templates {
+	for i, rawTempl := range rawTemplates {
 		tmpl, err := template.New("macro").Parse(rawTempl)
 		if err != nil {
 			return nil, err
@@ -49,7 +48,7 @@ func (t *Templates) GetExecuter(args []string) (core.Executer, error) {
 			return nil, err
 		}
 
-		cmd, err := command.NewFactory(nil).Create(output.String())
+		cmd, err := NewFactory(nil).Create(output.String())
 		if err != nil {
 			return nil, err
 		}
@@ -61,5 +60,5 @@ func (t *Templates) GetExecuter(args []string) (core.Executer, error) {
 		return cmds[0], nil
 	}
 
-	return command.NewSequence(cmds), nil
+	return NewSequence(cmds), nil
 }

--- a/pkg/core/command/macro_test.go
+++ b/pkg/core/command/macro_test.go
@@ -1,9 +1,8 @@
-package macro
+package command
 
 import (
 	"testing"
 
-	"github.com/ksysoev/wsget/pkg/core/command"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +37,7 @@ func TestNewMacroTemplates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Act
-			result, err := NewMacroTemplates(tt.templates)
+			result, err := NewMacro(tt.templates)
 
 			// Assert
 			if tt.wantErr {
@@ -109,7 +108,7 @@ func TestTemplates_GetExecuter(t *testing.T) {
 		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			// Arrange
-			templates, err := NewMacroTemplates(tt.templates)
+			templates, err := NewMacro(tt.templates)
 			assert.NoError(t, err)
 
 			// Act
@@ -124,7 +123,7 @@ func TestTemplates_GetExecuter(t *testing.T) {
 				assert.NotNil(t, executer)
 
 				if tt.expectedCmds > 1 {
-					_, ok := executer.(*command.Sequence)
+					_, ok := executer.(*Sequence)
 					assert.True(t, ok)
 				}
 			}

--- a/pkg/repo/macro/config.go
+++ b/pkg/repo/macro/config.go
@@ -1,0 +1,74 @@
+package macro
+
+import (
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+type config struct {
+	Version string              `yaml:"version"`
+	Source  string              `yaml:"source"`
+	Macro   map[string][]string `yaml:"macro"`
+	Domains []string            `yaml:"domains"`
+}
+
+func newConfig(src io.Reader) (*config, error) {
+	var cfg *config
+
+	decoder := yaml.NewDecoder(src)
+	if err := decoder.Decode(&cfg); err != nil {
+		return nil, err
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func (c *config) SetSource(source string) {
+	c.Source = source
+}
+
+func (c *config) CreateRepo() (*Repo, error) {
+	repo := New(c.Domains)
+
+	for name, rawCommands := range c.Macro {
+		err := repo.AddCommands(name, rawCommands)
+		if err != nil {
+			return nil, fmt.Errorf("fail to add macro: %w", err)
+		}
+	}
+
+	return repo, nil
+}
+
+func (c *config) validate() error {
+	if c.Version != "1" {
+		return fmt.Errorf("unsupported macro version: %s", c.Version)
+	}
+
+	if len(c.Domains) == 0 {
+		return fmt.Errorf("domains are required")
+	}
+
+	if len(c.Macro) == 0 {
+		return fmt.Errorf("macro commands are required")
+	}
+
+	return nil
+}
+
+func (c *config) WriteTo(w io.Writer) (err error) {
+	enc := yaml.NewEncoder(w)
+	defer func() {
+		if e := enc.Close(); err == nil && e != nil {
+			err = fmt.Errorf("fail to write config: %w", e)
+		}
+	}()
+
+	return enc.Encode(c)
+}

--- a/pkg/repo/macro/config.go
+++ b/pkg/repo/macro/config.go
@@ -7,13 +7,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// config represents the configuration structure used for YAML parsing and validation.
+// It contains fields for the version, source file, macros, and associated domains.
 type config struct {
 	Version string              `yaml:"version"`
-	Source  string              `yaml:"source"`
+	Source  string              `yaml:"source,omitempty"`
 	Macro   map[string][]string `yaml:"macro"`
 	Domains []string            `yaml:"domains"`
 }
 
+// newConfig creates and initializes a new config object from the provided YAML input.
+// It takes src of type io.Reader which contains the YAML configuration data.
+// It returns a pointer to a config instance and an error if the decoding or validation of the configuration fails.
 func newConfig(src io.Reader) (*config, error) {
 	var cfg *config
 
@@ -29,10 +34,16 @@ func newConfig(src io.Reader) (*config, error) {
 	return cfg, nil
 }
 
+// SetSource sets the Source field of the config struct to the provided string value.
+// It takes source of type string as input and updates the Source field of the receiver.
+// It does not return any values and does not perform validation on the input.
 func (c *config) SetSource(source string) {
 	c.Source = source
 }
 
+// CreateRepo initializes and returns a new Repo based on the config's domains and macros.
+// It returns a pointer to a Repo instance and an error.
+// It returns an error if adding any macro commands to the Repo fails.
 func (c *config) CreateRepo() (*Repo, error) {
 	repo := New(c.Domains)
 
@@ -46,6 +57,8 @@ func (c *config) CreateRepo() (*Repo, error) {
 	return repo, nil
 }
 
+// validate ensures that the config structure is properly initialized and contains valid data.
+// It returns an error if the Version is unsupported, Domains are empty, or Macro commands are missing.
 func (c *config) validate() error {
 	if c.Version != "1" {
 		return fmt.Errorf("unsupported macro version: %s", c.Version)
@@ -62,7 +75,10 @@ func (c *config) validate() error {
 	return nil
 }
 
-func (c *config) WriteTo(w io.Writer) (err error) {
+// Write encodes the config structure in YAML format and writes it to the provided io.Writer.
+// It takes w of type io.Writer as input.
+// It returns an error if the YAML encoding fails or if closing the encoder encounters an error.
+func (c *config) Write(w io.Writer) (err error) {
 	enc := yaml.NewEncoder(w)
 	defer func() {
 		if e := enc.Close(); err == nil && e != nil {

--- a/pkg/repo/macro/config_test.go
+++ b/pkg/repo/macro/config_test.go
@@ -38,7 +38,7 @@ macro:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			buf.WriteString(tt.input)
+			_, _ = buf.WriteString(tt.input)
 
 			// Act
 			result, err := newConfig(&buf)
@@ -169,16 +169,18 @@ func (m *mockWriter) Write(p []byte) (n int, err error) {
 	if m.fail {
 		return 0, assert.AnError
 	}
+
 	m.output += string(p)
+
 	return len(p), nil
 }
 
 func TestConfig_Write(t *testing.T) {
 	tests := []struct {
-		name       string
-		config     *config
-		wantOutput string
 		wantErr    error
+		config     *config
+		name       string
+		wantOutput string
 	}{
 		{
 			name: "valid config writes successfully",

--- a/pkg/repo/macro/config_test.go
+++ b/pkg/repo/macro/config_test.go
@@ -1,0 +1,238 @@
+package macro
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		validateErr error
+		expectedErr string
+	}{
+		{
+			name: "valid config",
+			input: `
+version: 1
+domains: ["example.com"]
+macro:
+  test: ["exit"]
+`,
+		},
+		{
+			name:        "invalid YAML format",
+			input:       "key: : value",
+			expectedErr: "yaml: mapping values are not allowed in this context",
+		},
+		{
+			name:        "validation error",
+			input:       `version: 2`,
+			expectedErr: "unsupported macro version: 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			buf.WriteString(tt.input)
+
+			// Act
+			result, err := newConfig(&buf)
+
+			// Assert
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestConfig_SetSource(t *testing.T) {
+	// Arrange
+	c := &config{}
+
+	// Act
+	c.SetSource("test")
+
+	// Assert
+	assert.Equal(t, "test", c.Source)
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *config
+		expectedErr string
+	}{
+		{
+			name: "valid config",
+			config: &config{
+				Version: "1",
+				Domains: []string{"example.com"},
+				Macro: map[string][]string{
+					"test": {"exit"},
+				},
+			},
+		},
+		{
+			name: "unsupported version",
+			config: &config{
+				Version: "2",
+			},
+			expectedErr: "unsupported macro version: 2",
+		},
+		{
+			name: "missing domains",
+			config: &config{
+				Version: "1",
+			},
+			expectedErr: "domains are required",
+		},
+		{
+			name: "missing macro commands",
+			config: &config{
+				Version: "1",
+				Domains: []string{"example.com"},
+			},
+			expectedErr: "macro commands are required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Act
+			err := tt.config.validate()
+
+			// Assert
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfig_CreateRepo(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *config
+		wantErr string
+	}{
+		{
+			name: "valid config with commands",
+			config: &config{
+				Macro: map[string][]string{"test": {"exit"}},
+			},
+		},
+		{
+			name: "error adding commands",
+			config: &config{
+				Macro: map[string][]string{"test": {"invalid {{ command }"}},
+			},
+			wantErr: "fail to add macro: template: macro:1: function \"command\" not defined",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Act
+			repo, err := tt.config.CreateRepo()
+
+			// Assert
+			if tt.wantErr != "" {
+				assert.Nil(t, repo)
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NotNil(t, repo)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// mockWriter is a mock implementation of io.Writer to simulate writing scenarios.
+type mockWriter struct {
+	output string
+	fail   bool
+}
+
+func (m *mockWriter) Write(p []byte) (n int, err error) {
+	if m.fail {
+		return 0, assert.AnError
+	}
+	m.output += string(p)
+	return len(p), nil
+}
+
+func TestConfig_Write(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     *config
+		wantOutput string
+		wantErr    error
+	}{
+		{
+			name: "valid config writes successfully",
+			config: &config{
+				Version: "1",
+				Domains: []string{"example.com"},
+				Macro:   map[string][]string{"test": {"exit"}},
+			},
+			wantOutput: `version: "1"
+macro:
+    test:
+        - exit
+domains:
+    - example.com
+`,
+		},
+		{
+			name: "empty config writes successfully",
+			config: &config{
+				Version: "",
+				Domains: nil,
+				Macro:   nil,
+			},
+			wantOutput: "version: \"\"\nmacro: {}\ndomains: []\n",
+		},
+		{
+			name: "error during writing",
+			config: &config{
+				Version: "1",
+				Domains: []string{"example.com"},
+				Macro:   map[string][]string{"test": {"exit"}},
+			},
+			wantErr: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			writer := &mockWriter{}
+			if tt.wantErr != nil {
+				writer.fail = true
+			}
+
+			// Act
+			err := tt.config.Write(writer)
+
+			// Assert
+			if tt.wantErr != nil {
+				assert.ErrorContains(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantOutput, writer.output)
+			}
+		})
+	}
+}

--- a/pkg/repo/macro/fetching.go
+++ b/pkg/repo/macro/fetching.go
@@ -1,0 +1,71 @@
+package macro
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Download downloads a macro configuration file from the specified URL and saves it to the given file path.
+// It takes filepath of type string and url of type string as inputs.
+// It returns an error if the download fails, the file already exists, the YAML unmarshalling fails, or the macro version is unsupported.
+func Download(filepath, url string) error {
+	resp, err := http.Get(url) //nolint:gosec // This is a CLI tool, and the URL is provided by the user
+
+	if err != nil {
+		return fmt.Errorf("fail to download macro: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("fail to download macro: %s", resp.Status)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("fail to read macro file: %w", err)
+	}
+
+	var cfg config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("fail to unmarshal macro: %w", err)
+	}
+
+	if cfg.Version != "1" {
+		return fmt.Errorf("unsupported macro version: %s", cfg.Version)
+	}
+
+	m := New(nil)
+	for name, rawCommands := range cfg.Macro {
+		if err := m.AddCommands(name, rawCommands); err != nil {
+			return err
+		}
+	}
+
+	cfg.Source = url
+
+	data, err = yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("fail to download macro: %w", err)
+	}
+
+	if !strings.HasSuffix(filepath, ".yaml") || !strings.HasSuffix(filepath, ".yml") {
+		filepath += ".yml"
+	}
+
+	if _, err := os.Stat(filepath); err == nil {
+		return fmt.Errorf("file %s already exists, please use update command or use different name", filepath)
+	}
+
+	// Save the downloaded macro to the file
+	if err := os.WriteFile(filepath, data, 0o600); err != nil {
+		return fmt.Errorf("fail to download macro to file %s: %w", filepath, err)
+	}
+
+	return nil
+}

--- a/pkg/repo/macro/fetching.go
+++ b/pkg/repo/macro/fetching.go
@@ -2,7 +2,6 @@ package macro
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -26,30 +25,14 @@ func Download(filepath, url string) error {
 		return fmt.Errorf("fail to download macro: %s", resp.Status)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	_, cfg, err := parseConfig(resp.Body)
 	if err != nil {
-		return fmt.Errorf("fail to read macro file: %w", err)
-	}
-
-	var cfg config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("fail to unmarshal macro: %w", err)
-	}
-
-	if cfg.Version != "1" {
-		return fmt.Errorf("unsupported macro version: %s", cfg.Version)
-	}
-
-	m := New(nil)
-	for name, rawCommands := range cfg.Macro {
-		if err := m.AddCommands(name, rawCommands); err != nil {
-			return err
-		}
+		return fmt.Errorf("fail to download macro: %w", err)
 	}
 
 	cfg.Source = url
 
-	data, err = yaml.Marshal(cfg)
+	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("fail to download macro: %w", err)
 	}

--- a/pkg/repo/macro/fetching.go
+++ b/pkg/repo/macro/fetching.go
@@ -11,7 +11,6 @@ import (
 // It returns an error if the download fails, the file already exists, the YAML unmarshalling fails, or the macro version is unsupported.
 func Download(filepath, url string) (err error) {
 	resp, err := http.Get(url) //nolint:gosec // This is a CLI tool, and the URL is provided by the user
-
 	if err != nil {
 		return fmt.Errorf("fail to download macro: %w", err)
 	}

--- a/pkg/repo/macro/fetching.go
+++ b/pkg/repo/macro/fetching.go
@@ -44,7 +44,7 @@ func Download(filepath, url string) (err error) {
 		}
 	}()
 
-	if err := cfg.WriteTo(file); err != nil {
+	if err := cfg.Write(file); err != nil {
 		return fmt.Errorf("fail to write macro: %w", err)
 	}
 

--- a/pkg/repo/macro/fething_test.go
+++ b/pkg/repo/macro/fething_test.go
@@ -1,0 +1,104 @@
+package macro
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDownload(t *testing.T) {
+	const validConfig = `
+version: 1
+domains: ["example.com"]
+macro:
+  test: ["exit"]
+`
+
+	tests := []struct {
+		name        string
+		filepath    string
+		mockResp    *http.Response
+		mockErr     error
+		expectedErr string
+		url         string
+	}{
+		{
+			name:     "successful download and save",
+			filepath: "macro.yaml",
+			mockResp: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(validConfig)),
+			},
+		},
+		{
+			name:        "non-200 status code",
+			filepath:    "macro.yaml",
+			mockResp:    &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(bytes.NewBufferString(""))},
+			expectedErr: "fail to download macro: 404 Not Found",
+		},
+		{
+			name:        "invalid config format",
+			filepath:    "macro.yaml",
+			mockResp:    &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString("invalid yaml"))},
+			expectedErr: "fail to download macro: yaml: unmarshal errors",
+		},
+		{
+			name:        "file creation failure",
+			filepath:    "/invalid/path/macro.yaml",
+			mockResp:    &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(validConfig))},
+			expectedErr: "no such file or directory",
+		},
+		{
+			name:     "fail get request",
+			filepath: "macro.yaml",
+
+			expectedErr: "connect: connection refused",
+			url:         "http://localhost:1234",
+		},
+		{
+			name:     "fail to parse commands",
+			filepath: "macro.yaml",
+			mockResp: &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(bytes.NewBufferString(`
+version: 1
+domains: ["example.com"]
+macro: 
+  test: ["invalid {{ command"]
+`)),
+			},
+			expectedErr: `function "command" not defined`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			httpServ := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.mockResp.StatusCode)
+				_, _ = io.Copy(w, tt.mockResp.Body)
+			}))
+
+			t.Cleanup(httpServ.Close)
+
+			url := httpServ.URL
+			if tt.url != "" {
+				url = tt.url
+			}
+
+			err := Download(filepath.Join(tmpDir, tt.filepath), url)
+
+			if tt.expectedErr != "" {
+				assert.ErrorContains(t, err, tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/repo/macro/macro.go
+++ b/pkg/repo/macro/macro.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ksysoev/wsget/pkg/core"
+	"github.com/ksysoev/wsget/pkg/core/command"
 	"gopkg.in/yaml.v3"
 )
 
@@ -20,7 +21,7 @@ type Config struct {
 }
 
 type Macro struct {
-	macro   map[string]*Templates
+	macro   map[string]*command.Templates
 	domains []string
 }
 
@@ -29,7 +30,7 @@ type Macro struct {
 // Returns a pointer to the newly created Macro instance.
 func NewMacro(domains []string) *Macro {
 	return &Macro{
-		macro:   make(map[string]*Templates),
+		macro:   make(map[string]*command.Templates),
 		domains: domains,
 	}
 }
@@ -48,7 +49,7 @@ func (m *Macro) AddCommands(name string, rawCommands []string) error {
 		return fmt.Errorf("empty macro: %s", name)
 	}
 
-	templs, err := NewMacroTemplates(rawCommands)
+	templs, err := command.NewMacro(rawCommands)
 
 	if err != nil {
 		return err
@@ -176,7 +177,8 @@ func LoadMacroForDomain(macroDir, domain string) (*Macro, error) {
 }
 
 func (m *Macro) Download(filepath, url string) error {
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) //nolint:gosec // This is a CLI tool, and the URL is provided by the user
+
 	if err != nil {
 		return fmt.Errorf("fail to download macro: %w", err)
 	}
@@ -219,7 +221,7 @@ func (m *Macro) Download(filepath, url string) error {
 	}
 
 	// Save the downloaded macro to the file
-	if err := os.WriteFile(filepath, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath, data, 0o600); err != nil {
 		return fmt.Errorf("fail to download macro to file %s: %w", filepath, err)
 	}
 

--- a/pkg/repo/macro/macro.go
+++ b/pkg/repo/macro/macro.go
@@ -2,9 +2,7 @@ package macro
 
 import (
 	"fmt"
-	"io"
 	"log"
-	"net/http"
 	"os"
 	"strings"
 
@@ -13,34 +11,34 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type Config struct {
+type config struct {
 	Version string              `yaml:"version"`
 	Source  string              `yaml:"source"`
 	Macro   map[string][]string `yaml:"macro"`
 	Domains []string            `yaml:"domains"`
 }
 
-type Macro struct {
+type Repo struct {
 	macro   map[string]*command.Templates
 	domains []string
 }
 
-// NewMacro creates a new Macro instance with the specified domains.
+// New creates a new Repo instance with the specified domains.
 // The domains parameter is a slice of strings representing the allowed domains for the macro.
-// Returns a pointer to the newly created Macro instance.
-func NewMacro(domains []string) *Macro {
-	return &Macro{
+// Returns a pointer to the newly created Repo instance.
+func New(domains []string) *Repo {
+	return &Repo{
 		macro:   make(map[string]*command.Templates),
 		domains: domains,
 	}
 }
 
-// AddCommands adds a new macro with the given name and commands to the Macro instance.
+// AddCommands adds a new macro with the given name and commands to the Repo instance.
 // If a macro with the same name already exists, it returns an error.
 // If the rawCommands slice is empty, it returns an error.
 // If the rawCommands slice has only one command, it adds the command directly to the macro.
 // Otherwise, it creates a new Sequence with the commands and adds it to the macro.
-func (m *Macro) AddCommands(name string, rawCommands []string) error {
+func (m *Repo) AddCommands(name string, rawCommands []string) error {
 	if _, ok := m.macro[name]; ok {
 		return fmt.Errorf("duplicate macro: %s", name)
 	}
@@ -62,7 +60,7 @@ func (m *Macro) AddCommands(name string, rawCommands []string) error {
 
 // merge merges the given macro into the current macro.
 // If a macro with the same name already exists, an error is returned.
-func (m *Macro) merge(macro *Macro) error {
+func (m *Repo) merge(macro *Repo) error {
 	for name, cmd := range macro.macro {
 		if _, ok := m.macro[name]; ok {
 			return fmt.Errorf("duplicate macro: %s", name)
@@ -75,7 +73,7 @@ func (m *Macro) merge(macro *Macro) error {
 }
 
 // Get returns the Executer associated with the given name, or an error if the name is not found.
-func (m *Macro) Get(name, argString string) (core.Executer, error) {
+func (m *Repo) Get(name, argString string) (core.Executer, error) {
 	if cmd, ok := m.macro[name]; ok {
 		args := strings.Fields(argString)
 		return cmd.GetExecuter(args)
@@ -84,10 +82,10 @@ func (m *Macro) Get(name, argString string) (core.Executer, error) {
 	return nil, fmt.Errorf("unknown command: %s", name)
 }
 
-// GetNames returns a list of all macro names stored in the Macro instance.
+// GetNames returns a list of all macro names stored in the Repo instance.
 // It does not take any parameters.
 // It returns a slice of strings containing the names of the macros.
-func (m *Macro) GetNames() []string {
+func (m *Repo) GetNames() []string {
 	names := make([]string, 0, len(m.macro))
 
 	for name := range m.macro {
@@ -98,14 +96,14 @@ func (m *Macro) GetNames() []string {
 }
 
 // LoadFromFile loads a macro configuration from a file at the given path.
-// It returns a Macro instance and an error if the file cannot be read or parsed.
-func LoadFromFile(path string) (*Macro, error) {
+// It returns a Repo instance and an error if the file cannot be read or parsed.
+func LoadFromFile(path string) (*Repo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	var cfg Config
+	var cfg config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
@@ -114,7 +112,7 @@ func LoadFromFile(path string) (*Macro, error) {
 		return nil, fmt.Errorf("unsupported macro version: %s", cfg.Version)
 	}
 
-	macroCfg := NewMacro(cfg.Domains)
+	macroCfg := New(cfg.Domains)
 
 	for name, rawCommands := range cfg.Macro {
 		if err := macroCfg.AddCommands(name, rawCommands); err != nil {
@@ -127,16 +125,16 @@ func LoadFromFile(path string) (*Macro, error) {
 
 // LoadMacroForDomain loads and merges macros for a specific domain from YAML files in a given directory.
 // It takes macroDir, a string specifying the directory path, and domain, a string specifying the target domain.
-// It returns a pointer to a Macro containing merged macros for the domain, or an error in case of failure.
+// It returns a pointer to a Repo containing merged macros for the domain, or an error in case of failure.
 // Errors may occur if the directory cannot be read, files cannot be parsed, or macros fail to merge.
 // Ignores non-YAML files, directories, and files without a matching domain.
-func LoadMacroForDomain(macroDir, domain string) (*Macro, error) {
+func LoadMacroForDomain(macroDir, domain string) (*Repo, error) {
 	files, err := os.ReadDir(macroDir)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	var macro *Macro
+	var macro *Repo
 
 	for _, file := range files {
 		if file.IsDir() || (!strings.HasSuffix(file.Name(), ".yaml") && !strings.HasSuffix(file.Name(), ".yml")) {
@@ -174,56 +172,4 @@ func LoadMacroForDomain(macroDir, domain string) (*Macro, error) {
 	}
 
 	return macro, nil
-}
-
-func (m *Macro) Download(filepath, url string) error {
-	resp, err := http.Get(url) //nolint:gosec // This is a CLI tool, and the URL is provided by the user
-
-	if err != nil {
-		return fmt.Errorf("fail to download macro: %w", err)
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("fail to download macro: %s", resp.Status)
-	}
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("fail to read macro file: %w", err)
-	}
-
-	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("fail to unmarshal macro: %w", err)
-	}
-
-	if cfg.Version != "1" {
-		return fmt.Errorf("unsupported macro version: %s", cfg.Version)
-	}
-
-	for name, rawCommands := range cfg.Macro {
-		if err := m.AddCommands(name, rawCommands); err != nil {
-			return err
-		}
-	}
-
-	cfg.Source = url
-
-	data, err = yaml.Marshal(cfg)
-	if err != nil {
-		return fmt.Errorf("fail to download macro: %w", err)
-	}
-
-	if !strings.HasSuffix(filepath, ".yaml") || !strings.HasSuffix(filepath, ".yml") {
-		filepath += ".yml"
-	}
-
-	// Save the downloaded macro to the file
-	if err := os.WriteFile(filepath, data, 0o600); err != nil {
-		return fmt.Errorf("fail to download macro to file %s: %w", filepath, err)
-	}
-
-	return nil
 }

--- a/pkg/repo/macro/macro.go
+++ b/pkg/repo/macro/macro.go
@@ -214,6 +214,8 @@ func (m *Macro) Download(filepath, url string) error {
 		return fmt.Errorf("fail to download macro: %w", err)
 	}
 
+	fmt.Println(filepath)
+
 	// Save the downloaded macro to the file
 	if err := os.WriteFile(filepath, data, os.ModePerm); err != nil {
 		return fmt.Errorf("fail to download macro to file %s: %w", filepath, err)

--- a/pkg/repo/macro/macro.go
+++ b/pkg/repo/macro/macro.go
@@ -214,7 +214,9 @@ func (m *Macro) Download(filepath, url string) error {
 		return fmt.Errorf("fail to download macro: %w", err)
 	}
 
-	fmt.Println(filepath)
+	if !strings.HasSuffix(filepath, ".yaml") || !strings.HasSuffix(filepath, ".yml") {
+		filepath += ".yml"
+	}
 
 	// Save the downloaded macro to the file
 	if err := os.WriteFile(filepath, data, os.ModePerm); err != nil {

--- a/pkg/repo/macro/macro_test.go
+++ b/pkg/repo/macro/macro_test.go
@@ -12,13 +12,13 @@ import (
 func TestNewMacro(t *testing.T) {
 	tests := []struct {
 		name    string
-		want    *Macro
+		want    *Repo
 		domains []string
 	}{
 		{
 			name:    "empty domains",
 			domains: []string{},
-			want: &Macro{
+			want: &Repo{
 				macro:   make(map[string]*command.Templates),
 				domains: []string{},
 			},
@@ -26,7 +26,7 @@ func TestNewMacro(t *testing.T) {
 		{
 			name:    "non-empty domains",
 			domains: []string{"example.com", "google.com"},
-			want: &Macro{
+			want: &Repo{
 				macro:   make(map[string]*command.Templates),
 				domains: []string{"example.com", "google.com"},
 			},
@@ -35,12 +35,12 @@ func TestNewMacro(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewMacro(tt.domains); got == nil {
-				t.Errorf("NewMacro() = %v, want non-nil", got)
+			if got := New(tt.domains); got == nil {
+				t.Errorf("New() = %v, want non-nil", got)
 			} else if len(got.macro) != 0 {
-				t.Errorf("NewMacro() = %v, want empty macro map", got)
+				t.Errorf("New() = %v, want empty macro map", got)
 			} else if len(got.domains) != len(tt.domains) {
-				t.Errorf("NewMacro() = %v, want domains %v", got, tt.domains)
+				t.Errorf("New() = %v, want domains %v", got, tt.domains)
 			}
 		})
 	}
@@ -48,42 +48,42 @@ func TestNewMacro(t *testing.T) {
 func TestMacro_AddCommands(t *testing.T) {
 	tests := []struct {
 		name        string
-		macro       *Macro
+		macro       *Repo
 		commandName string
 		commands    []string
 		wantErr     bool
 	}{
 		{
 			name:        "add new macro",
-			macro:       NewMacro([]string{}),
+			macro:       New([]string{}),
 			commandName: "test",
 			commands:    []string{"edit hello"},
 			wantErr:     false,
 		},
 		{
 			name:        "add existing macro",
-			macro:       &Macro{macro: map[string]*command.Templates{"test": nil}},
+			macro:       &Repo{macro: map[string]*command.Templates{"test": nil}},
 			commandName: "test",
 			commands:    []string{"send hello"},
 			wantErr:     true,
 		},
 		{
 			name:        "empty macro",
-			macro:       NewMacro([]string{}),
+			macro:       New([]string{}),
 			commandName: "test",
 			commands:    []string{},
 			wantErr:     true,
 		},
 		{
 			name:        "single command macro",
-			macro:       NewMacro([]string{}),
+			macro:       New([]string{}),
 			commandName: "test",
 			commands:    []string{"exit hello"},
 			wantErr:     false,
 		},
 		{
 			name:        "multi command macro",
-			macro:       NewMacro([]string{}),
+			macro:       New([]string{}),
 			commandName: "test",
 			commands:    []string{"send hello", "wait 5"},
 			wantErr:     false,
@@ -94,26 +94,26 @@ func TestMacro_AddCommands(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.macro.AddCommands(tt.commandName, tt.commands)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Macro.AddCommands() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Repo.AddCommands() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 func TestMacro_Merge(t *testing.T) {
 	tests := []struct {
-		macro       *Macro
-		otherMacro  *Macro
+		macro       *Repo
+		otherMacro  *Repo
 		name        string
 		expectedLen int
 		wantErr     bool
 	}{
 		{
 			name: "merge empty macro with empty macro",
-			macro: &Macro{
+			macro: &Repo{
 				macro:   make(map[string]*command.Templates),
 				domains: []string{},
 			},
-			otherMacro: &Macro{
+			otherMacro: &Repo{
 				macro:   make(map[string]*command.Templates),
 				domains: []string{},
 			},
@@ -122,13 +122,13 @@ func TestMacro_Merge(t *testing.T) {
 		},
 		{
 			name: "merge non-empty macro with empty macro",
-			macro: &Macro{
+			macro: &Repo{
 				macro: map[string]*command.Templates{
 					"test": nil,
 				},
 				domains: []string{},
 			},
-			otherMacro: &Macro{
+			otherMacro: &Repo{
 				macro:   make(map[string]*command.Templates),
 				domains: []string{},
 			},
@@ -137,11 +137,11 @@ func TestMacro_Merge(t *testing.T) {
 		},
 		{
 			name: "merge empty macro with non-empty macro",
-			macro: &Macro{
+			macro: &Repo{
 				macro:   make(map[string]*command.Templates),
 				domains: []string{},
 			},
-			otherMacro: &Macro{
+			otherMacro: &Repo{
 				macro: map[string]*command.Templates{
 					"test": nil,
 				},
@@ -152,13 +152,13 @@ func TestMacro_Merge(t *testing.T) {
 		},
 		{
 			name: "merge non-empty macro with non-empty macro",
-			macro: &Macro{
+			macro: &Repo{
 				macro: map[string]*command.Templates{
 					"test": nil,
 				},
 				domains: []string{},
 			},
-			otherMacro: &Macro{
+			otherMacro: &Repo{
 				macro: map[string]*command.Templates{
 					"test2": nil,
 				},
@@ -169,13 +169,13 @@ func TestMacro_Merge(t *testing.T) {
 		},
 		{
 			name: "merge macro with duplicate macro name",
-			macro: &Macro{
+			macro: &Repo{
 				macro: map[string]*command.Templates{
 					"test": nil,
 				},
 				domains: []string{},
 			},
-			otherMacro: &Macro{
+			otherMacro: &Repo{
 				macro: map[string]*command.Templates{
 					"test": nil,
 				},
@@ -190,9 +190,9 @@ func TestMacro_Merge(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.macro.merge(tt.otherMacro)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Macro.merge() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Repo.merge() error = %v, wantErr %v", err, tt.wantErr)
 			} else if len(tt.macro.macro) != tt.expectedLen {
-				t.Errorf("Macro.merge() expected length of macro map = %d, got %d", tt.expectedLen, len(tt.macro.macro))
+				t.Errorf("Repo.merge() expected length of macro map = %d, got %d", tt.expectedLen, len(tt.macro.macro))
 			}
 		})
 	}
@@ -201,7 +201,7 @@ func TestMacro_Get(t *testing.T) {
 	testTemplate, _ := command.NewMacro([]string{"exit"})
 	tests := []struct {
 		name    string
-		macro   *Macro
+		macro   *Repo
 		cmdName string
 		wantCmd core.Executer
 		errMsg  string
@@ -209,7 +209,7 @@ func TestMacro_Get(t *testing.T) {
 	}{
 		{
 			name:    "get existing command",
-			macro:   &Macro{macro: map[string]*command.Templates{"test": testTemplate}},
+			macro:   &Repo{macro: map[string]*command.Templates{"test": testTemplate}},
 			cmdName: "test",
 			wantCmd: command.NewExit(),
 			wantErr: false,
@@ -217,7 +217,7 @@ func TestMacro_Get(t *testing.T) {
 		},
 		{
 			name:    "get non-existing command",
-			macro:   &Macro{macro: map[string]*command.Templates{}},
+			macro:   &Repo{macro: map[string]*command.Templates{}},
 			cmdName: "test",
 			wantCmd: nil,
 			wantErr: true,
@@ -225,7 +225,7 @@ func TestMacro_Get(t *testing.T) {
 		},
 		{
 			name:    "get command with empty macro",
-			macro:   &Macro{macro: map[string]*command.Templates{}},
+			macro:   &Repo{macro: map[string]*command.Templates{}},
 			cmdName: "",
 			wantCmd: nil,
 			wantErr: true,
@@ -233,7 +233,7 @@ func TestMacro_Get(t *testing.T) {
 		},
 		{
 			name:    "get command with non-empty macro",
-			macro:   &Macro{macro: map[string]*command.Templates{"test": nil}},
+			macro:   &Repo{macro: map[string]*command.Templates{"test": nil}},
 			cmdName: "",
 			wantCmd: nil,
 			wantErr: true,
@@ -245,15 +245,15 @@ func TestMacro_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd, err := tt.macro.Get(tt.cmdName, "")
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Macro.Get() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Repo.Get() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if err != nil && err.Error() != tt.errMsg {
-				t.Errorf("Macro.Get() error message = %v, want %v", err.Error(), tt.errMsg)
+				t.Errorf("Repo.Get() error message = %v, want %v", err.Error(), tt.errMsg)
 			}
 
 			if cmd != tt.wantCmd {
-				t.Errorf("Macro.Get() cmd = %v, want %v", cmd, tt.wantCmd)
+				t.Errorf("Repo.Get() cmd = %v, want %v", cmd, tt.wantCmd)
 			}
 		})
 	}
@@ -379,19 +379,19 @@ func TestLoadFromFile_NotExists(t *testing.T) {
 func TestMacro_GetNames(t *testing.T) {
 	tests := []struct {
 		name  string
-		macro *Macro
+		macro *Repo
 		want  []string
 	}{
 		{
 			name: "empty macro",
-			macro: &Macro{
+			macro: &Repo{
 				macro: map[string]*command.Templates{},
 			},
 			want: []string{},
 		},
 		{
 			name: "single command macro",
-			macro: &Macro{
+			macro: &Repo{
 				macro: map[string]*command.Templates{
 					"test": nil,
 				},
@@ -400,7 +400,7 @@ func TestMacro_GetNames(t *testing.T) {
 		},
 		{
 			name: "multiple command macro",
-			macro: &Macro{
+			macro: &Repo{
 				macro: map[string]*command.Templates{
 					"command1": nil,
 					"command2": nil,

--- a/pkg/repo/macro/macro_test.go
+++ b/pkg/repo/macro/macro_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ksysoev/wsget/pkg/core"
 	"github.com/ksysoev/wsget/pkg/core/command"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMacro(t *testing.T) {
@@ -354,19 +355,11 @@ macro:
     - send hello
     - wait 5
 `)
-	if err != nil {
-		t.Fatalf("Failed to write to temporary test file: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Load macro from temporary test file
 	_, err = LoadFromFile(tempFile.Name())
-	if err == nil {
-		t.Fatalf("LoadFromFile() error = %v, want non-nil", err)
-	}
-
-	if err.Error() != "unsupported macro version: 2" {
-		t.Errorf("LoadFromFile() error = %v, want unsupported macro version: 2", err)
-	}
+	assert.ErrorContains(t, err, "unsupported macro version")
 }
 
 func TestLoadFromFile_NotExists(t *testing.T) {

--- a/pkg/repo/macro/macro_test.go
+++ b/pkg/repo/macro/macro_test.go
@@ -19,7 +19,7 @@ func TestNewMacro(t *testing.T) {
 			name:    "empty domains",
 			domains: []string{},
 			want: &Macro{
-				macro:   make(map[string]*Templates),
+				macro:   make(map[string]*command.Templates),
 				domains: []string{},
 			},
 		},
@@ -27,7 +27,7 @@ func TestNewMacro(t *testing.T) {
 			name:    "non-empty domains",
 			domains: []string{"example.com", "google.com"},
 			want: &Macro{
-				macro:   make(map[string]*Templates),
+				macro:   make(map[string]*command.Templates),
 				domains: []string{"example.com", "google.com"},
 			},
 		},
@@ -62,7 +62,7 @@ func TestMacro_AddCommands(t *testing.T) {
 		},
 		{
 			name:        "add existing macro",
-			macro:       &Macro{macro: map[string]*Templates{"test": nil}},
+			macro:       &Macro{macro: map[string]*command.Templates{"test": nil}},
 			commandName: "test",
 			commands:    []string{"send hello"},
 			wantErr:     true,
@@ -110,11 +110,11 @@ func TestMacro_Merge(t *testing.T) {
 		{
 			name: "merge empty macro with empty macro",
 			macro: &Macro{
-				macro:   make(map[string]*Templates),
+				macro:   make(map[string]*command.Templates),
 				domains: []string{},
 			},
 			otherMacro: &Macro{
-				macro:   make(map[string]*Templates),
+				macro:   make(map[string]*command.Templates),
 				domains: []string{},
 			},
 			wantErr:     false,
@@ -123,13 +123,13 @@ func TestMacro_Merge(t *testing.T) {
 		{
 			name: "merge non-empty macro with empty macro",
 			macro: &Macro{
-				macro: map[string]*Templates{
+				macro: map[string]*command.Templates{
 					"test": nil,
 				},
 				domains: []string{},
 			},
 			otherMacro: &Macro{
-				macro:   make(map[string]*Templates),
+				macro:   make(map[string]*command.Templates),
 				domains: []string{},
 			},
 			wantErr:     false,
@@ -138,11 +138,11 @@ func TestMacro_Merge(t *testing.T) {
 		{
 			name: "merge empty macro with non-empty macro",
 			macro: &Macro{
-				macro:   make(map[string]*Templates),
+				macro:   make(map[string]*command.Templates),
 				domains: []string{},
 			},
 			otherMacro: &Macro{
-				macro: map[string]*Templates{
+				macro: map[string]*command.Templates{
 					"test": nil,
 				},
 				domains: []string{},
@@ -153,13 +153,13 @@ func TestMacro_Merge(t *testing.T) {
 		{
 			name: "merge non-empty macro with non-empty macro",
 			macro: &Macro{
-				macro: map[string]*Templates{
+				macro: map[string]*command.Templates{
 					"test": nil,
 				},
 				domains: []string{},
 			},
 			otherMacro: &Macro{
-				macro: map[string]*Templates{
+				macro: map[string]*command.Templates{
 					"test2": nil,
 				},
 				domains: []string{},
@@ -170,13 +170,13 @@ func TestMacro_Merge(t *testing.T) {
 		{
 			name: "merge macro with duplicate macro name",
 			macro: &Macro{
-				macro: map[string]*Templates{
+				macro: map[string]*command.Templates{
 					"test": nil,
 				},
 				domains: []string{},
 			},
 			otherMacro: &Macro{
-				macro: map[string]*Templates{
+				macro: map[string]*command.Templates{
 					"test": nil,
 				},
 				domains: []string{},
@@ -198,7 +198,7 @@ func TestMacro_Merge(t *testing.T) {
 	}
 }
 func TestMacro_Get(t *testing.T) {
-	testTemplate, _ := NewMacroTemplates([]string{"exit"})
+	testTemplate, _ := command.NewMacro([]string{"exit"})
 	tests := []struct {
 		name    string
 		macro   *Macro
@@ -209,7 +209,7 @@ func TestMacro_Get(t *testing.T) {
 	}{
 		{
 			name:    "get existing command",
-			macro:   &Macro{macro: map[string]*Templates{"test": testTemplate}},
+			macro:   &Macro{macro: map[string]*command.Templates{"test": testTemplate}},
 			cmdName: "test",
 			wantCmd: command.NewExit(),
 			wantErr: false,
@@ -217,7 +217,7 @@ func TestMacro_Get(t *testing.T) {
 		},
 		{
 			name:    "get non-existing command",
-			macro:   &Macro{macro: map[string]*Templates{}},
+			macro:   &Macro{macro: map[string]*command.Templates{}},
 			cmdName: "test",
 			wantCmd: nil,
 			wantErr: true,
@@ -225,7 +225,7 @@ func TestMacro_Get(t *testing.T) {
 		},
 		{
 			name:    "get command with empty macro",
-			macro:   &Macro{macro: map[string]*Templates{}},
+			macro:   &Macro{macro: map[string]*command.Templates{}},
 			cmdName: "",
 			wantCmd: nil,
 			wantErr: true,
@@ -233,7 +233,7 @@ func TestMacro_Get(t *testing.T) {
 		},
 		{
 			name:    "get command with non-empty macro",
-			macro:   &Macro{macro: map[string]*Templates{"test": nil}},
+			macro:   &Macro{macro: map[string]*command.Templates{"test": nil}},
 			cmdName: "",
 			wantCmd: nil,
 			wantErr: true,
@@ -385,14 +385,14 @@ func TestMacro_GetNames(t *testing.T) {
 		{
 			name: "empty macro",
 			macro: &Macro{
-				macro: map[string]*Templates{},
+				macro: map[string]*command.Templates{},
 			},
 			want: []string{},
 		},
 		{
 			name: "single command macro",
 			macro: &Macro{
-				macro: map[string]*Templates{
+				macro: map[string]*command.Templates{
 					"test": nil,
 				},
 			},
@@ -401,7 +401,7 @@ func TestMacro_GetNames(t *testing.T) {
 		{
 			name: "multiple command macro",
 			macro: &Macro{
-				macro: map[string]*Templates{
+				macro: map[string]*command.Templates{
 					"command1": nil,
 					"command2": nil,
 					"command3": nil,


### PR DESCRIPTION
**Description:**
- Implement the "download" subcommand under "init" for fetching macro files from a given URL.
- Initial setup includes command structure and flag parsing; execution logic remains a placeholder.