### PR TITLE
Add configurable timeout for WebSocket connections

### DIFF
--- a/pkg/cmd/connect.go
+++ b/pkg/cmd/connect.go
@@ -58,6 +58,7 @@ func runConnectCmd(ctx context.Context, args *flags, unnamedArgs []string) error
 		SkipSSLVerification: args.insecure,
 		Headers:             args.headers,
 		MaxMessageSize:      args.maxMsgSize,
+		Timeout:             time.Duration(args.timeout) * time.Second,
 	}
 
 	if args.verbose {

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -38,6 +38,7 @@ type flags struct {
 	headers      []string
 	maxMsgSize   int64
 	waitResponse int
+	timeout      uint32
 	insecure     bool
 	verbose      bool
 }
@@ -69,6 +70,7 @@ func InitCommands(version string) *cobra.Command {
 	cmd.Flags().StringVarP(&args.inputFile, "input", "i", "", "Input YAML file with list of requests to send to the server")
 	cmd.Flags().BoolVarP(&args.verbose, "verbose", "v", false, "Verbose output")
 	cmd.Flags().Int64VarP(&args.maxMsgSize, "max-size", "s", ws.DefaultMaxMessageSize, "Maximum message size in bytes, non-positive value will be ignored and default value will be used")
+	cmd.Flags().Uint32VarP(&args.timeout, "timeout", "t", 30, "WebSocket handshake timeout in seconds, 0 means no timeout")
 
 	args.configDir = cmp.Or(args.configDir, os.Getenv("WSGET_CONFIG_DIR"))
 

--- a/pkg/ws/ws.go
+++ b/pkg/ws/ws.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	headerPartsNumber     = 2
-	dialTimeout           = 15 * time.Second
 	DefaultMaxMessageSize = 1024 * 1024
 )
 
@@ -45,6 +44,7 @@ type Options struct {
 	Headers             []string
 	SkipSSLVerification bool
 	MaxMessageSize      int64
+	Timeout             time.Duration
 }
 
 // New initializes a new WebSocket connection configuration with specified URL and options.
@@ -62,7 +62,7 @@ func New(wsURL string, opts Options) (*Connection, error) {
 
 	httpCli := &http.Client{
 		Transport: newRequestLogger(opts.Output, opts.SkipSSLVerification),
-		Timeout:   dialTimeout,
+		Timeout:   opts.Timeout,
 	}
 
 	wsOpts := &websocket.DialOptions{


### PR DESCRIPTION
### Summary of Changes
- Introduced a configurable timeout for WebSocket handshake and connection operations.
- Added a `--timeout` flag allowing users to specify a timeout duration.
- Default timeout is set to 30 seconds if not explicitly configured.
