### PR TITLE
Set read-only permissions for GitHub Actions workflow contents

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: WSGet
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The pull request updates the GitHub Actions workflow to enforce read-only permissions for its contents. This enhances security by limiting unnecessary write access.