### PR TITLE
Handshake duration in verbose mode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     - unparam
     - unused
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     errcheck:
       check-type-assertions: true

--- a/pkg/cmd/connect_test.go
+++ b/pkg/cmd/connect_test.go
@@ -287,7 +287,6 @@ func TestRunConnectCmd_SuccessConnect(t *testing.T) {
 	// tty is not available in the test environment
 	// so the test will fail in some cases and be successful in others
 	err := runConnectCmd(ctx, args, []string{url})
-
 	if err != nil {
 		assert.ErrorContains(t, err, "open /dev/tty: ")
 	} else {

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -41,6 +41,7 @@ type flags struct {
 	timeout      uint32
 	insecure     bool
 	verbose      bool
+	profile      bool
 }
 
 // InitCommands initializes and returns a new cobra.Command for the wsget tool.
@@ -71,6 +72,7 @@ func InitCommands(version string) *cobra.Command {
 	cmd.Flags().BoolVarP(&args.verbose, "verbose", "v", false, "Verbose output")
 	cmd.Flags().Int64VarP(&args.maxMsgSize, "max-size", "s", ws.DefaultMaxMessageSize, "Maximum message size in bytes, non-positive value will be ignored and default value will be used")
 	cmd.Flags().Uint32VarP(&args.timeout, "timeout", "t", 30, "WebSocket handshake timeout in seconds, 0 means no timeout")
+	cmd.Flags().BoolVarP(&args.profile, "profile", "p", false, "Enable profiling and display timing for network operations")
 
 	args.configDir = cmp.Or(args.configDir, os.Getenv("WSGET_CONFIG_DIR"))
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -41,7 +41,6 @@ type flags struct {
 	timeout      uint32
 	insecure     bool
 	verbose      bool
-	profile      bool
 }
 
 // InitCommands initializes and returns a new cobra.Command for the wsget tool.
@@ -72,7 +71,6 @@ func InitCommands(version string) *cobra.Command {
 	cmd.Flags().BoolVarP(&args.verbose, "verbose", "v", false, "Verbose output")
 	cmd.Flags().Int64VarP(&args.maxMsgSize, "max-size", "s", ws.DefaultMaxMessageSize, "Maximum message size in bytes, non-positive value will be ignored and default value will be used")
 	cmd.Flags().Uint32VarP(&args.timeout, "timeout", "t", 30, "WebSocket handshake timeout in seconds, 0 means no timeout")
-	cmd.Flags().BoolVarP(&args.profile, "profile", "p", false, "Enable profiling and display timing for network operations")
 
 	args.configDir = cmp.Or(args.configDir, os.Getenv("WSGET_CONFIG_DIR"))
 

--- a/pkg/core/cli.go
+++ b/pkg/core/cli.go
@@ -136,7 +136,6 @@ func (c *CLI) Run(ctx context.Context, opts RunOptions) error {
 			var err error
 			for cmd != nil {
 				cmd, err = cmd.Execute(exCtx)
-
 				if err != nil {
 					return err
 				}
@@ -183,7 +182,6 @@ func (c *CLI) Run(ctx context.Context, opts RunOptions) error {
 			}
 
 			cmd, err := c.cmdFactory.Create(fmt.Sprintf("print %s %s", msg.Type.String(), msg.Data))
-
 			if err != nil {
 				return fmt.Errorf("fail to create print command: %w", err)
 			}

--- a/pkg/core/cli_test.go
+++ b/pkg/core/cli_test.go
@@ -43,11 +43,13 @@ func TestNewCLI(t *testing.T) {
 	cancel()
 
 	done := make(chan bool)
+
 	go func() {
 		err := cli.Run(ctx, RunOptions{})
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
+
 		done <- true
 	}()
 
@@ -74,7 +76,6 @@ func TestNewCLIRunWithCommands(t *testing.T) {
 	cmd.EXPECT().Execute(mock.Anything).Return(nil, ErrInterrupted)
 
 	err := cli.Run(context.Background(), RunOptions{Commands: []Executer{cmd}})
-
 	if err == nil {
 		t.Fatalf("Expected error, but got nothing")
 	}

--- a/pkg/core/command/commands.go
+++ b/pkg/core/command/commands.go
@@ -81,7 +81,6 @@ func NewPrintMsg(msg core.Message) *PrintMsg {
 // If an output file is provided, it writes the formatted message to the file.
 func (c *PrintMsg) Execute(exCtx core.ExecutionContext) (core.Executer, error) {
 	output, err := exCtx.FormatMessage(c.msg, false)
-
 	if err != nil {
 		return nil, fmt.Errorf("fail to format message: %w", err)
 	}
@@ -175,7 +174,6 @@ func (c *CmdEdit) Execute(exCtx core.ExecutionContext) (core.Executer, error) {
 	}
 
 	cmd, err := exCtx.CreateCommand(rawCmd)
-
 	if err != nil {
 		err := exCtx.Print(fmt.Sprintf("Invalid command: %s\n", rawCmd), color.FgRed)
 		return nil, err

--- a/pkg/core/command/commands_test.go
+++ b/pkg/core/command/commands_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestExit_Execute(t *testing.T) {
 	c := NewExit()
-	_, err := c.Execute(nil)
 
+	_, err := c.Execute(nil)
 	if err == nil {
 		t.Errorf("Exit.Execute() error = %v, wantErr %v", err, true)
 	}

--- a/pkg/core/command/commands_test.go
+++ b/pkg/core/command/commands_test.go
@@ -377,6 +377,7 @@ func TestRepeat_Execute(t *testing.T) {
 
 				exCtx := core.NewMockExecutionContext(t)
 				exCtx.EXPECT().WaitForResponse(1*time.Millisecond).Return(core.Message{}, assert.AnError)
+
 				return exCtx
 			},
 		},
@@ -451,6 +452,7 @@ func TestEdit_Execute(t *testing.T) {
 
 				exCtx := core.NewMockExecutionContext(t)
 				exCtx.EXPECT().EditorMode("test-content").Return("test-response", nil)
+
 				return exCtx
 			},
 		},
@@ -464,6 +466,7 @@ func TestEdit_Execute(t *testing.T) {
 
 				exCtx := core.NewMockExecutionContext(t)
 				exCtx.EXPECT().EditorMode("error-content").Return("", assert.AnError)
+
 				return exCtx
 			},
 		},
@@ -512,6 +515,7 @@ func TestSend_Execute(t *testing.T) {
 
 				exCtx := core.NewMockExecutionContext(t)
 				exCtx.EXPECT().SendRequest(mockRequest).Return(nil)
+
 				return exCtx
 			},
 		},
@@ -525,6 +529,7 @@ func TestSend_Execute(t *testing.T) {
 
 				exCtx := core.NewMockExecutionContext(t)
 				exCtx.EXPECT().SendRequest(mockRequest).Return(assert.AnError)
+
 				return exCtx
 			},
 		},
@@ -623,6 +628,7 @@ func TestInputFileCommand_Execute(t *testing.T) {
 				if cmd == "valid-command" {
 					return NewPrintMsg(core.Message{Type: core.Request, Data: cmd}), nil
 				}
+
 				return nil, assert.AnError
 			},
 			expectedErr:     true,

--- a/pkg/core/context.go
+++ b/pkg/core/context.go
@@ -73,6 +73,7 @@ func (c *executionContext) WaitForResponse(timeout time.Duration) (Message, erro
 
 	if timeout > 0 {
 		var cancel context.CancelFunc
+
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}

--- a/pkg/core/context_test.go
+++ b/pkg/core/context_test.go
@@ -221,8 +221,10 @@ func TestExecutionContext_WaitForResponse(t *testing.T) {
 			timeout: 1 * time.Millisecond,
 			setupCLI: func(_ context.Context) *CLI {
 				msgChan := make(chan Message, 1)
+
 				go func() {
 					time.Sleep(2 * time.Second)
+
 					msgChan <- Message{Type: Response, Data: "Response Data"}
 				}()
 
@@ -238,8 +240,10 @@ func TestExecutionContext_WaitForResponse(t *testing.T) {
 			timeout: 1 * time.Millisecond,
 			setupCLI: func(_ context.Context) *CLI {
 				msgChan := make(chan Message, 1)
+
 				go func() {
 					time.Sleep(1 * time.Second)
+
 					msgChan <- Message{Type: Response, Data: "Response Data"}
 				}()
 

--- a/pkg/core/edit/editor_test.go
+++ b/pkg/core/edit/editor_test.go
@@ -53,7 +53,6 @@ func TestEdit(t *testing.T) {
 	}()
 
 	req, err := editor.Edit(context.Background(), "")
-
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -118,7 +117,6 @@ func TestEditInterrupted(t *testing.T) {
 	}()
 
 	req, err := editor.Edit(context.Background(), "")
-
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -213,7 +211,6 @@ func TestEditClosingKeyboard(t *testing.T) {
 	editor.SetInput(keyStream)
 
 	req, err := editor.Edit(context.Background(), "")
-
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -247,7 +244,6 @@ func TestEditSpecialKeys(t *testing.T) {
 	}()
 
 	req, err := editor.Edit(context.Background(), "")
-
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/pkg/core/formater/formater.go
+++ b/pkg/core/formater/formater.go
@@ -77,8 +77,8 @@ func (f *Format) formatJSONMessage(msgType string, data any) (string, error) {
 // If the string is not a valid JSON, it returns false as the second value.
 func (f *Format) parseJSON(data string) (any, bool) {
 	var obj any
-	err := json.Unmarshal([]byte(data), &obj)
 
+	err := json.Unmarshal([]byte(data), &obj)
 	if err != nil {
 		return obj, false
 	}

--- a/pkg/core/formater/text_test.go
+++ b/pkg/core/formater/text_test.go
@@ -12,7 +12,6 @@ func TestTextFormat_FormatRequest(t *testing.T) {
 	expectedOutput := color.New(color.FgGreen).Sprintf("test request data")
 
 	output, err := tf.FormatRequest(data)
-
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -28,7 +27,6 @@ func TestTextFormat_FormatResponse(t *testing.T) {
 	expectedOutput := color.New(color.FgHiRed).Sprintf("test response data")
 
 	output, err := tf.FormatResponse(data)
-
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -45,7 +43,6 @@ func TestTextFormat_FormatForFile(t *testing.T) {
 	expectedOutput := "test data"
 
 	output, err := tf.FormatForFile(data)
-
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/pkg/repo/history/history_test.go
+++ b/pkg/repo/history/history_test.go
@@ -253,7 +253,9 @@ func TestHistory_LoadHistory(t *testing.T) {
 				if err != nil {
 					return err
 				}
+
 				defer func() { _ = f.Close() }()
+
 				return nil
 			},
 			expectedError: false,
@@ -267,8 +269,11 @@ func TestHistory_LoadHistory(t *testing.T) {
 				if err != nil {
 					return err
 				}
+
 				defer func() { _ = f.Close() }()
+
 				_, err = f.WriteString("entry1\n")
+
 				return err
 			},
 			expectedError: false,
@@ -282,8 +287,11 @@ func TestHistory_LoadHistory(t *testing.T) {
 				if err != nil {
 					return err
 				}
+
 				defer func() { _ = f.Close() }()
+
 				_, err = f.WriteString("entry1\nentry2\nentry3\n")
+
 				return err
 			},
 			expectedError: false,
@@ -297,8 +305,11 @@ func TestHistory_LoadHistory(t *testing.T) {
 				if err != nil {
 					return err
 				}
+
 				defer func() { _ = f.Close() }()
+
 				_, err = f.WriteString("\nentry1\n\nentry2\n\nentry3\n\n")
+
 				return err
 			},
 			expectedError: false,

--- a/pkg/repo/macro/config.go
+++ b/pkg/repo/macro/config.go
@@ -80,6 +80,7 @@ func (c *config) validate() error {
 // It returns an error if the YAML encoding fails or if closing the encoder encounters an error.
 func (c *config) Write(w io.Writer) (err error) {
 	enc := yaml.NewEncoder(w)
+
 	defer func() {
 		if e := enc.Close(); err == nil && e != nil {
 			err = fmt.Errorf("fail to write config: %w", e)

--- a/pkg/repo/macro/config_test.go
+++ b/pkg/repo/macro/config_test.go
@@ -38,6 +38,7 @@ macro:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
+
 			_, _ = buf.WriteString(tt.input)
 
 			// Act

--- a/pkg/repo/macro/macro.go
+++ b/pkg/repo/macro/macro.go
@@ -40,7 +40,6 @@ func (m *Repo) AddCommands(name string, rawCommands []string) error {
 	}
 
 	macro, err := command.NewMacro(rawCommands)
-
 	if err != nil {
 		return err
 	}
@@ -128,7 +127,6 @@ func LoadMacroForDomain(macroDir, domain string) (*Repo, error) {
 		}
 
 		fileMacro, err := LoadFromFile(macroDir + "/" + file.Name())
-
 		if err != nil {
 			return nil, err
 		}
@@ -150,7 +148,6 @@ func LoadMacroForDomain(macroDir, domain string) (*Repo, error) {
 			macro = fileMacro
 		} else {
 			err := macro.merge(fileMacro)
-
 			if err != nil {
 				return nil, fmt.Errorf("fail to loading macro from file %s, %w ", file.Name(), err)
 			}

--- a/pkg/repo/macro/macro_test.go
+++ b/pkg/repo/macro/macro_test.go
@@ -279,7 +279,6 @@ macro:
     - send hello
     - wait 5
 `)
-
 	if err != nil {
 		t.Fatalf("Failed to write to temporary test file: %v", err)
 	}
@@ -304,7 +303,6 @@ macro:
 	}
 
 	cmd, err := macro.Get("test", "")
-
 	if err != nil {
 		t.Errorf("LoadFromFile() error = %v, want nil", err)
 	}

--- a/pkg/ws/reqlog.go
+++ b/pkg/ws/reqlog.go
@@ -44,7 +44,6 @@ func (rl *requestLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	resp, err := rl.transport.RoundTrip(req)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ws/ws.go
+++ b/pkg/ws/ws.go
@@ -28,14 +28,14 @@ type reader interface {
 }
 
 type Connection struct {
+	output    io.Writer
 	url       *url.URL
 	ws        *websocket.Conn
 	onMessage func(context.Context, []byte)
 	opts      *websocket.DialOptions
 	ready     chan struct{}
-	l         sync.Mutex
 	msgSize   int64
-	output    io.Writer
+	l         sync.Mutex
 }
 
 type Options struct {
@@ -133,6 +133,7 @@ func (c *Connection) Connect(ctx context.Context) error {
 	}
 
 	c.l.Lock()
+
 	if c.ws != nil {
 		c.l.Unlock()
 		return fmt.Errorf("connection already established")


### PR DESCRIPTION
This pull request introduces a minor refactor and a new feature to the WebSocket connection logic in `pkg/ws/ws.go`. The main improvement is the addition of optional logging for WebSocket handshake duration, which can help with debugging and performance monitoring. Additionally, there are some small code cleanups and struct organization improvements.

**New feature: WebSocket handshake timing**

* Added an optional `output` field to the `Connection` struct and `Options` to allow writing handshake timing information. When `output` is set, the duration of the WebSocket handshake is printed after connection. (F957921cL35, F957921cL92, F957921cL115)

**Code organization and cleanup**

* Refactored the declaration of `ErrConnectionClosed` from a var block to a single line, simplifying the error definition. (F957921cL21)
* Minor whitespace cleanup in the `requestLogger`'s `RoundTrip` method for consistency. (F767281fL44)