### PR TITLE
Replace panic with error

### DIFF
--- a/pkg/core/formater/formater.go
+++ b/pkg/core/formater/formater.go
@@ -55,7 +55,7 @@ func (f *Format) formatTextMessage(msgType, data string) (string, error) {
 	case "NotDefined":
 		return "", fmt.Errorf("unknown message type")
 	default:
-		panic("Unexpected message type: " + msgType)
+		return "", fmt.Errorf("unexpected message type: %s", msgType)
 	}
 }
 
@@ -69,7 +69,7 @@ func (f *Format) formatJSONMessage(msgType string, data any) (string, error) {
 	case "NotDefined":
 		return "", fmt.Errorf("unknown message type")
 	default:
-		panic("Unexpected message type: " + msgType)
+		return "", fmt.Errorf("unexpected message type: %s", msgType)
 	}
 }
 

--- a/pkg/core/formater/formater_test.go
+++ b/pkg/core/formater/formater_test.go
@@ -204,8 +204,7 @@ func TestFormat_UnexpectedTextMessageType(t *testing.T) {
 	formater := NewFormat()
 
 	_, err := formater.formatTextMessage("Unknown", "test")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unexpected message type")
+	assert.ErrorContains(t, err, "unexpected message type")
 }
 
 func TestFormat_UnexpectedJSONMessageType(t *testing.T) {
@@ -216,8 +215,7 @@ func TestFormat_UnexpectedJSONMessageType(t *testing.T) {
 	}
 
 	_, err := formater.formatJSONMessage("Unknown", testData)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unexpected message type")
+	assert.ErrorContains(t, err, "unexpected message type")
 }
 
 func TestFormatMessage_UnexpectedType(t *testing.T) {
@@ -225,11 +223,9 @@ func TestFormatMessage_UnexpectedType(t *testing.T) {
 
 	// Test with text data
 	_, err := formater.FormatMessage("Unknown", "test")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unexpected message type")
+	assert.ErrorContains(t, err, "unexpected message type")
 
 	// Test with JSON data
 	_, err = formater.FormatMessage("Unknown", `{"test": "data"}`)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unexpected message type")
+	assert.ErrorContains(t, err, "unexpected message type")
 }

--- a/pkg/core/formater/formater_test.go
+++ b/pkg/core/formater/formater_test.go
@@ -199,3 +199,37 @@ func TestFormat_parseJSON(t *testing.T) {
 	assert.False(t, ok)
 	assert.Nil(t, parsedInvalidJSON)
 }
+
+func TestFormat_UnexpectedTextMessageType(t *testing.T) {
+	formater := NewFormat()
+
+	_, err := formater.formatTextMessage("Unknown", "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message type")
+}
+
+func TestFormat_UnexpectedJSONMessageType(t *testing.T) {
+	formater := NewFormat()
+
+	testData := map[string]interface{}{
+		"test": "data",
+	}
+
+	_, err := formater.formatJSONMessage("Unknown", testData)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message type")
+}
+
+func TestFormatMessage_UnexpectedType(t *testing.T) {
+	formater := NewFormat()
+
+	// Test with text data
+	_, err := formater.FormatMessage("Unknown", "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message type")
+
+	// Test with JSON data
+	_, err = formater.FormatMessage("Unknown", `{"test": "data"}`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message type")
+}


### PR DESCRIPTION
This pull request improves error handling in the `Format` struct by replacing panics with more descriptive error returns when an unexpected message type is encountered. It also adds comprehensive unit tests to ensure these error cases are handled correctly.

Error handling improvements:

* Replaced the use of `panic` with returning a formatted error message when an unexpected message type is passed to `formatTextMessage` and `formatJSONMessage` in `formater.go`. [[1]](diffhunk://#diff-f74d3c5d7c9d7f8ea91985003135da3df4a8918af736819085d29ce2a0ac0f7dL58-R58) [[2]](diffhunk://#diff-f74d3c5d7c9d7f8ea91985003135da3df4a8918af736819085d29ce2a0ac0f7dL72-R72)

Testing enhancements:

* Added new unit tests in `formater_test.go` to verify that `formatTextMessage`, `formatJSONMessage`, and `FormatMessage` all return errors with the expected message when given an unknown message type.