### PR TITLE
Fix header parsing to support values containing colons

### DIFF
--- a/pkg/ws/ws.go
+++ b/pkg/ws/ws.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	headerPartsNumber     = 2
 	DefaultMaxMessageSize = 1024 * 1024
 )
 
@@ -72,15 +71,12 @@ func New(wsURL string, opts *Options) (*Connection, error) {
 	headers := make(http.Header)
 
 	for _, headerInput := range opts.Headers {
-		splited := strings.Split(headerInput, ":")
-		if len(splited) != headerPartsNumber {
+		header, value, found := strings.Cut(headerInput, ":")
+		if !found {
 			return nil, fmt.Errorf("invalid header: %s", headerInput)
 		}
 
-		header := strings.TrimSpace(splited[0])
-		value := strings.TrimSpace(splited[1])
-
-		headers.Add(header, value)
+		headers.Add(strings.TrimSpace(header), strings.TrimSpace(value))
 	}
 
 	if opts.UserAgent != "" && headers.Get("User-Agent") == "" {

--- a/pkg/ws/ws_test.go
+++ b/pkg/ws/ws_test.go
@@ -134,6 +134,22 @@ func TestNew(t *testing.T) {
 			wantError: false,
 		},
 		{
+			name: "Header value containing colons",
+			url:  "ws://localhost:8080",
+			options: &Options{
+				Headers: []string{"Authorization: Bearer abc:def"},
+			},
+			wantError: false,
+		},
+		{
+			name: "Header value with multiple colons",
+			url:  "ws://localhost:8080",
+			options: &Options{
+				Headers: []string{"X-Custom: value:with:colons"},
+			},
+			wantError: false,
+		},
+		{
 			name:      "Invalid URL format",
 			url:       "invalid_url" + string(rune(0)),
 			options:   &Options{},
@@ -217,6 +233,45 @@ func TestNew_MultipleValuesForSameHeader(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"a=1", "b=2"}, conn.opts.HTTPHeader["Cookie"])
+}
+
+func TestNew_HeaderValueWithColons(t *testing.T) {
+	tests := []struct {
+		name          string
+		headerInput   string
+		expectedName  string
+		expectedValue string
+	}{
+		{
+			name:          "Bearer token with colon in value",
+			headerInput:   "Authorization: Bearer abc:def",
+			expectedName:  "Authorization",
+			expectedValue: "Bearer abc:def",
+		},
+		{
+			name:          "Header value with multiple colons",
+			headerInput:   "X-Custom: value:with:colons",
+			expectedName:  "X-Custom",
+			expectedValue: "value:with:colons",
+		},
+		{
+			name:          "Simple header without colons in value",
+			headerInput:   "Authorization: Bearer token",
+			expectedName:  "Authorization",
+			expectedValue: "Bearer token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, err := New("ws://localhost:8080", &Options{
+				Headers: []string{tt.headerInput},
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedValue, conn.opts.HTTPHeader.Get(tt.expectedName))
+		})
+	}
 }
 
 func TestConnection_Connect_UserAgent(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replaces `strings.Split(headerInput, ":")` + `len == 2` guard with `strings.Cut(headerInput, ":")`, splitting only on the first colon
- Header values containing colons (e.g. `Authorization: Bearer abc:def`, `X-Custom: value:with:colons`) are now parsed correctly instead of being rejected with an `invalid header` error
- Removes the now-redundant `headerPartsNumber` constant

## Testing

- Added two new cases to the existing `TestNew` table: `"Header value containing colons"` and `"Header value with multiple colons"`
- Added `TestNew_HeaderValueWithColons` to assert that the parsed name and value are correct for all colon-in-value scenarios

Fixes #126