### PR TITLE
fix: protect c.ws access with mutex in Send, Ping, and Close

### DIFF
--- a/pkg/ws/ws.go
+++ b/pkg/ws/ws.go
@@ -247,7 +247,15 @@ func (c *Connection) Send(ctx context.Context, msg string) error {
 		return fmt.Errorf("context canceled while waiting to send: %w", ctx.Err())
 	}
 
-	err := c.ws.Write(ctx, websocket.MessageText, []byte(msg))
+	c.l.Lock()
+	ws := c.ws
+	c.l.Unlock()
+
+	if ws == nil {
+		return fmt.Errorf("connection not established")
+	}
+
+	err := ws.Write(ctx, websocket.MessageText, []byte(msg))
 	if err != nil {
 		err = handleError(err)
 		if err != nil {
@@ -268,7 +276,15 @@ func (c *Connection) Ping(ctx context.Context) error {
 		return fmt.Errorf("context canceled while waiting to ping: %w", ctx.Err())
 	}
 
-	err := c.ws.Ping(ctx)
+	c.l.Lock()
+	ws := c.ws
+	c.l.Unlock()
+
+	if ws == nil {
+		return fmt.Errorf("connection not established")
+	}
+
+	err := ws.Ping(ctx)
 	if err != nil {
 		err = handleError(err)
 		if err != nil {
@@ -283,13 +299,15 @@ func (c *Connection) Ping(ctx context.Context) error {
 // It returns an error if the connection is not yet established.
 // The function ensures a normal closure status is sent to the WebSocket server.
 func (c *Connection) Close() error {
-	select {
-	case <-c.ready:
-	default:
+	c.l.Lock()
+	ws := c.ws
+	c.l.Unlock()
+
+	if ws == nil {
 		return fmt.Errorf("connection is not established")
 	}
 
-	return c.ws.Close(websocket.StatusNormalClosure, "closing connection")
+	return ws.Close(websocket.StatusNormalClosure, "closing connection")
 }
 
 // Ready returns a channel that is closed when the WebSocket connection is established.

--- a/pkg/ws/ws_test.go
+++ b/pkg/ws/ws_test.go
@@ -655,3 +655,51 @@ func TestConnection_Ping_NotConnected(t *testing.T) {
 	err = conn.Ping(ctx)
 	assert.Error(t, err)
 }
+
+func TestConnection_ConcurrentOperations(t *testing.T) {
+	s := httptest.NewServer(createEchoWSHandler())
+	defer s.Close()
+
+	conn, err := New("ws://"+s.Listener.Addr().String(), &Options{})
+	assert.NoError(t, err)
+
+	conn.SetOnMessage(func(context.Context, []byte) {})
+
+	connectDone := make(chan struct{})
+
+	go func() {
+		defer close(connectDone)
+
+		_ = conn.Connect(context.Background())
+	}()
+
+	// Wait until the connection is ready before hammering it concurrently.
+	select {
+	case <-conn.Ready():
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for connection")
+	}
+
+	const goroutines = 10
+
+	var wg sync.WaitGroup
+
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+
+			for range 20 {
+				_ = conn.Send(context.Background(), "ping")
+				_ = conn.Ping(context.Background())
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	_ = conn.Close()
+
+	<-connectDone
+}


### PR DESCRIPTION
## Summary

Fixes the race condition described in #117 where `c.ws` was read in `Send()`, `Ping()`, and `Close()` without holding the mutex, while `Connect()` writes it under the lock.

## Changes

- **`Send()`** — acquire lock, copy `c.ws` to a local variable, release lock, nil-check, then call `ws.Write()`
- **`Ping()`** — same pattern, then call `ws.Ping()`
- **`Close()`** — replace the non-atomic `select`-on-`ready` check with the same lock/copy/nil-check pattern, then call `ws.Close()`

The critical section is deliberately minimal (pointer copy only) so the lock is released before the actual WebSocket I/O, keeping the same non-blocking characteristics as before.

## Testing

Added `TestConnection_ConcurrentOperations`: 10 goroutines each calling `Send` and `Ping` 20 times concurrently against a live echo server.

```
go test -race ./pkg/ws/...   # PASS, no race warnings
go test -race ./...          # all packages PASS
golangci-lint run ./...      # 0 issues
```

Closes #117