### PR TITLE
fix: close channels and prevent goroutine leak in CLI.Run (fixes #118)

### DIFF
--- a/pkg/core/cli.go
+++ b/pkg/core/cli.go
@@ -27,6 +27,7 @@ type CLI struct {
 	editor      Editor
 	inputStream chan KeyEvent
 	messages    chan Message
+	done        chan struct{}
 	output      io.Writer
 	commands    chan Executer
 	cmdFactory  CommandFactory
@@ -84,6 +85,7 @@ func NewCLI(cmdFactory CommandFactory, wsConn ConnectionHandler, output io.Write
 		wsConn:      wsConn,
 		inputStream: make(chan KeyEvent),
 		messages:    make(chan Message),
+		done:        make(chan struct{}),
 		output:      output,
 		commands:    make(chan Executer, CommandsLimit),
 		cmdFactory:  cmdFactory,
@@ -102,7 +104,10 @@ func NewCLI(cmdFactory CommandFactory, wsConn ConnectionHandler, output io.Write
 }
 
 func (c *CLI) OnKeyEvent(event KeyEvent) {
-	c.inputStream <- event
+	select {
+	case c.inputStream <- event:
+	case <-c.done:
+	}
 }
 
 func (c *CLI) onMessage(ctx context.Context, msg Message) {
@@ -116,8 +121,10 @@ func (c *CLI) onMessage(ctx context.Context, msg Message) {
 // It listens for user input and executes commands accordingly.
 func (c *CLI) Run(ctx context.Context, opts RunOptions) error {
 	defer func() {
+		close(c.done)
 		c.showCursor()
 		close(c.messages)
+		close(c.commands)
 	}()
 
 	c.hideCursor()

--- a/pkg/core/cli_test.go
+++ b/pkg/core/cli_test.go
@@ -324,6 +324,98 @@ func TestCLI_Run_KeyboardEvents(t *testing.T) {
 	}
 }
 
+func TestCLI_ChannelsClosedAfterRun(t *testing.T) {
+	wsConn := NewMockConnectionHandler(t)
+	wsConn.EXPECT().SetOnMessage(mock.Anything)
+
+	factory := NewMockCommandFactory(t)
+
+	editor := NewMockEditor(t)
+	editor.EXPECT().SetInput(mock.Anything)
+
+	cli := NewCLI(factory, wsConn, os.Stdout, editor, NewMockFormater(t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- cli.Run(ctx, RunOptions{})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error from Run: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Run did not exit after context cancellation")
+	}
+
+	// done and commands channels should be closed after Run exits.
+	_, ok := <-cli.done
+	if ok {
+		t.Error("done should be closed after Run exits")
+	}
+
+	_, ok = <-cli.commands
+	if ok {
+		t.Error("commands should be closed after Run exits")
+	}
+
+	_, ok = <-cli.messages
+	if ok {
+		t.Error("messages should be closed after Run exits")
+	}
+}
+
+func TestCLI_OnKeyEvent_NonBlockingAfterRunExits(t *testing.T) {
+	wsConn := NewMockConnectionHandler(t)
+	wsConn.EXPECT().SetOnMessage(mock.Anything)
+
+	factory := NewMockCommandFactory(t)
+
+	editor := NewMockEditor(t)
+	editor.EXPECT().SetInput(mock.Anything)
+
+	cli := NewCLI(factory, wsConn, os.Stdout, editor, NewMockFormater(t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- cli.Run(ctx, RunOptions{})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-errCh:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Run did not exit after context cancellation")
+	}
+
+	// OnKeyEvent must not block after Run has exited.
+	done := make(chan struct{})
+
+	go func() {
+		cli.OnKeyEvent(KeyEvent{Key: KeyEnter})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success — OnKeyEvent returned without blocking
+	case <-time.After(100 * time.Millisecond):
+		t.Error("OnKeyEvent blocked after Run exited")
+	}
+}
+
 func TestCLI_Run_MessagesChannel(t *testing.T) {
 	wsConn := NewMockConnectionHandler(t)
 


### PR DESCRIPTION
## Summary

- Adds a `done chan struct{}` sentinel to `CLI`, closed at the top of the `Run()` defer, to signal shutdown to external goroutine callers.
- Fixes the goroutine leak in `OnKeyEvent`: the blocking send `c.inputStream <- event` is replaced with a select that also listens on `done`, mirroring the existing `onMessage` pattern. This ensures the keyboard goroutine never hangs after `Run` exits.
- Closes the `commands` and `messages` channels in the `Run()` defer alongside the existing cleanup. `inputStream` is intentionally **not** closed — it is written to by external callers and the `done` channel is sufficient to unblock all senders safely (closing it would risk a `send on closed channel` panic).

## Tests

Two new tests in `pkg/core/cli_test.go`:
- `TestCLI_ChannelsClosedAfterRun` — asserts `done`, `commands`, and `messages` are closed after `Run` returns.
- `TestCLI_OnKeyEvent_NonBlockingAfterRunExits` — asserts `OnKeyEvent` returns immediately instead of blocking after `Run` has exited.

All tests pass with `-race`:
```
ok  github.com/ksysoev/wsget/pkg/core   (race)
ok  github.com/ksysoev/wsget/pkg/core/command
ok  github.com/ksysoev/wsget/pkg/core/edit
ok  github.com/ksysoev/wsget/pkg/core/formater
```

Closes #118