### PR TITLE
Add documentation publishing workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,18 @@
+name: Publish Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ksysoev/omnidex/action@main
+        with:
+          omnidex_url: ${{ vars.OMNIDEX_URL }}
+          api_key: ${{ secrets.OMNIDEX_API_KEY }}
+          docs_path: .
+          file_pattern: README.md

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,4 +1,6 @@
 name: Publish Documentation
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-docs.yml` that triggers on every push to `main`
- Uses the `ksysoev/omnidex/action@main` reusable action to publish `README.md` to the Omnidex documentation portal
- Requires `OMNIDEX_URL` repository variable and `OMNIDEX_API_KEY` secret to be configured in the repo settings