### PR TITLE
chore: upgrade Go from 1.24.1 to 1.26.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Setup Go 1.24
+      - name: Setup Go 1.26
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24.x"
+          go-version: "1.26.x"
       - name: Display Go version
         run: go version
       - name: Code Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24.x"
+          go-version: "1.26.x"
       - name: Install Snapcraft
         run: |
           sudo snap install snapcraft --classic

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/wsget
 
-go 1.24.1
+go 1.26.1
 
 require (
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2

--- a/pkg/repo/macro/macro.go
+++ b/pkg/repo/macro/macro.go
@@ -94,7 +94,7 @@ func (m *Repo) GetNames() []string {
 // LoadFromFile loads a macro configuration from a file at the given path.
 // It returns a Repo instance and an error if the file cannot be read or parsed.
 func LoadFromFile(path string) (r *Repo, err error) {
-	file, err := os.Open(path) //nolint:gosec // path is a user-supplied CLI argument; taint analysis false positive
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("fail to open macro file %s: %w", path, err)
 	}

--- a/pkg/ws/reqlog.go
+++ b/pkg/ws/reqlog.go
@@ -36,7 +36,7 @@ func (rl *requestLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 		tx := color.New(color.FgGreen)
 		tx.SetWriter(rl.output)
 
-		_, _ = fmt.Fprintf(rl.output, "> %s %s %s\n", req.Method, req.URL.String(), req.Proto) //nolint:gosec // output is a trusted io.Writer; taint analysis false positive
+		_, _ = fmt.Fprintf(rl.output, "> %s %s %s\n", req.Method, req.URL.String(), req.Proto)
 		printHeaders(req.Header, rl.output, ">")
 		_, _ = fmt.Fprintln(rl.output)
 
@@ -52,7 +52,7 @@ func (rl *requestLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 		rx := color.New(color.FgYellow)
 		rx.SetWriter(rl.output)
 
-		_, _ = fmt.Fprintf(rl.output, "< %s %s\n", resp.Proto, resp.Status) //nolint:gosec // output is a trusted io.Writer; taint analysis false positive
+		_, _ = fmt.Fprintf(rl.output, "< %s %s\n", resp.Proto, resp.Status)
 		printHeaders(resp.Header, rl.output, "<")
 		_, _ = fmt.Fprintln(rl.output)
 		rx.UnsetWriter(rl.output)
@@ -76,7 +76,7 @@ func printHeaders(headers http.Header, out io.Writer, prefix string) {
 	for _, header := range headerNames {
 		values := headers[header]
 		for _, value := range values {
-			_, _ = fmt.Fprintf(out, "%s %s: %s\n", prefix, header, value) //nolint:gosec // out is a trusted io.Writer; taint analysis false positive
+			_, _ = fmt.Fprintf(out, "%s %s: %s\n", prefix, header, value)
 		}
 	}
 }

--- a/pkg/ws/reqlog_test.go
+++ b/pkg/ws/reqlog_test.go
@@ -160,7 +160,7 @@ func TestRequestLogger_RoundTrip(t *testing.T) {
 
 			tt.request.URL, _ = url.Parse(s.URL)
 
-			resp, err := cl.Do(tt.request) //nolint:gosec // request URL is set from a local test server; taint analysis false positive
+			resp, err := cl.Do(tt.request)
 
 			if tt.expectError {
 				assert.Error(t, err)


### PR DESCRIPTION
## Summary

- Bump `go` directive in `go.mod` from `1.24.1` to `1.26.1`
- Update `go-version` input in `.github/workflows/main.yml` and `.github/workflows/release.yml` from `1.24.x` to `1.26.x`

## Verification

- `go mod tidy` — clean, no dependency changes
- `go build ./...` — all packages compile
- `go test -race ./...` — all tests pass
- `golangci-lint run` — 0 issues
- `fieldalignment -fix ./...` — no struct alignment changes needed